### PR TITLE
PE-6490: network portal quick wins

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "axios": "^1.6.7",
     "axios-retry": "^4.0.0",
     "base64-arraybuffer": "^1.0.2",
+    "better-react-mathjax": "^2.0.3",
     "dexie": "^4.0.8",
     "dexie-react-hooks": "^1.1.7",
     "fflate": "^0.8.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import WalletProvider from './components/WalletProvider';
 import AppRouterLayout from './layout/AppRouterLayout';
 import Loading from './pages/Loading';
 import NotFound from './pages/NotFound';
+import {MathJaxContext} from 'better-react-mathjax';
 
 // Main Pages
 // const Dashboard = React.lazy(() => import('./pages/Dashboard'));
@@ -53,7 +54,8 @@ function App() {
               <Report />
             </Suspense>
           }
-        />,
+        />
+        ,
         <Route
           path="gateways/:ownerId/reports"
           element={
@@ -61,7 +63,8 @@ function App() {
               <Reports />
             </Suspense>
           }
-        />,
+        />
+        ,
         <Route
           path="gateways/:ownerId/observe"
           element={
@@ -69,7 +72,8 @@ function App() {
               <Observe />
             </Suspense>
           }
-        />,
+        />
+        ,
         <Route
           path="gateways/:ownerId"
           element={
@@ -87,7 +91,7 @@ function App() {
           }
         />
         ,
-         <Route
+        <Route
           path="staking"
           element={
             <Suspense fallback={<Loading />}>
@@ -114,7 +118,9 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <GlobalDataProvider>
         <WalletProvider>
-          <RouterProvider router={router} />
+          <MathJaxContext>
+            <RouterProvider router={router} />
+          </MathJaxContext>
         </WalletProvider>
       </GlobalDataProvider>
     </QueryClientProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,12 @@ import {
   createRoutesFromElements,
 } from 'react-router-dom';
 
+import { MathJaxContext } from 'better-react-mathjax';
 import GlobalDataProvider from './components/GlobalDataProvider';
 import WalletProvider from './components/WalletProvider';
 import AppRouterLayout from './layout/AppRouterLayout';
 import Loading from './pages/Loading';
 import NotFound from './pages/NotFound';
-import {MathJaxContext} from 'better-react-mathjax';
 
 // Main Pages
 // const Dashboard = React.lazy(() => import('./pages/Dashboard'));

--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -20,16 +20,18 @@ const BaseModal = ({
         aria-hidden="true"
       />
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+      <div className="fixed inset-0 flex  w-screen items-center justify-center p-4">
         <Dialog.Panel
-          className={`relative items-stretch rounded-[12px] bg-[#111112] ${useDefaultPadding ? 'p-[32px]' : ''} text-center text-grey-100`}
+          className={`relative flex max-h-full flex-col items-stretch rounded-[12px] bg-[#111112] ${useDefaultPadding ? 'p-[32px]' : ''} text-center text-grey-100`}
         >
           {showCloseButton && (
             <button className="absolute right-[-28px] top-0" onClick={onClose}>
               <CloseIcon />
             </button>
           )}
-          {children}
+          <div className="flex grow flex-col overflow-y-auto scrollbar">
+            {children}
+          </div>
         </Dialog.Panel>
       </div>
     </Dialog>

--- a/src/components/modals/StakingModal.tsx
+++ b/src/components/modals/StakingModal.tsx
@@ -12,6 +12,7 @@ import { useGlobalState } from '@src/store';
 import { formatWithCommas } from '@src/utils';
 import { showErrorToast } from '@src/utils/toast';
 import { useQueryClient } from '@tanstack/react-query';
+import { MathJax } from 'better-react-mathjax';
 import { useState } from 'react';
 import Button, { ButtonType } from '../Button';
 import Tooltip from '../Tooltip';
@@ -360,7 +361,7 @@ const StakingModal = ({
                   message={
                     <div>
                       <p>{EAY_TOOLTIP_TEXT}</p>
-                      <p className="mt-4">{EAY_TOOLTIP_FORMULA}</p>
+                      <MathJax className="mt-4">{EAY_TOOLTIP_FORMULA}</MathJax>
                     </div>
                   }
                 >

--- a/src/components/modals/StakingModal.tsx
+++ b/src/components/modals/StakingModal.tsx
@@ -1,5 +1,11 @@
 import { IOToken, mIOToken } from '@ar.io/sdk/web';
-import { EAY_TOOLTIP_TEXT, IO_LABEL, WRITE_OPTIONS, log } from '@src/constants';
+import {
+  EAY_TOOLTIP_FORMULA,
+  EAY_TOOLTIP_TEXT,
+  IO_LABEL,
+  WRITE_OPTIONS,
+  log,
+} from '@src/constants';
 import useGateway from '@src/hooks/useGateway';
 import useRewardsInfo from '@src/hooks/useRewardsInfo';
 import { useGlobalState } from '@src/store';
@@ -265,7 +271,8 @@ const StakingModal = ({
             <div className="grow"></div>
             <div className="text-left text-xs text-low">
               {tab == 0
-                ? balances && `Available: ${formatWithCommas(balances.io)} ${IO_LABEL}`
+                ? balances &&
+                  `Available: ${formatWithCommas(balances.io)} ${IO_LABEL}`
                 : `Available to Unstake: ${formatWithCommas(currentStake)} ${IO_LABEL}`}
             </div>
           </div>
@@ -349,16 +356,22 @@ const StakingModal = ({
               label="EAY:"
               value={EAY}
               rightIcon={
-                <Tooltip message={EAY_TOOLTIP_TEXT}>
+                <Tooltip
+                  message={
+                    <div>
+                      <p>{EAY_TOOLTIP_TEXT}</p>
+                      <p className="mt-4">{EAY_TOOLTIP_FORMULA}</p>
+                    </div>
+                  }
+                >
                   <InfoIcon />
                 </Tooltip>
               }
             />
 
             <div className="pt-[16px] text-left">
-            <UnstakeWarning />
+              <UnstakeWarning />
             </div>
-
           </div>
         </div>
         <div className="flex size-full flex-col p-[32px]">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,6 @@ export const log = loglevel;
 export const EAY_TOOLTIP_TEXT =
   'EAY = Estimated yield ratio determined by projecting the current nominal reward conditions over the course of a year. Does NOT include potential observation rewards.';
 export const EAY_TOOLTIP_FORMULA =
-  'EAY = (RewardsSharePerEpoch / TotalDelegatedStake) * EPOCHS_PER_YEAR';
+  '\\(EAY = \\frac{RewardsSharedPerEpoch}{TotalDelegatedStake} * EpochsPerYear\\)';
 
 export const IO_LABEL = 'tIO';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,5 +47,7 @@ export const log = loglevel;
 
 export const EAY_TOOLTIP_TEXT =
   'EAY = Estimated yield ratio determined by projecting the current nominal reward conditions over the course of a year. Does NOT include potential observation rewards.';
+export const EAY_TOOLTIP_FORMULA =
+  'EAY = (RewardsSharePerEpoch / TotalDelegatedStake) * EPOCHS_PER_YEAR';
 
 export const IO_LABEL = 'tIO';

--- a/src/pages/Gateway/PropertyDisplayPanel.tsx
+++ b/src/pages/Gateway/PropertyDisplayPanel.tsx
@@ -83,7 +83,7 @@ const PropertyDisplayPanel = ({
     ? [
         {
           label: 'Reward Share Ratio:',
-          value: gateway?.settings.delegateRewardShareRatio,
+          value: `${gateway?.settings.delegateRewardShareRatio}%`,
         },
         {
           label: `Minimum Delegated Stake (${IO_LABEL}):`,

--- a/src/pages/Gateway/index.tsx
+++ b/src/pages/Gateway/index.tsx
@@ -381,7 +381,7 @@ const Gateway = () => {
             <div className="text-high">Stats</div>
           </div>
           <StatsBox
-            title="Start Time"
+            title="Join Date"
             value={
               gateway?.startTimestamp
                 ? formatDate(new Date(gateway?.startTimestamp))

--- a/src/pages/Gateways/index.tsx
+++ b/src/pages/Gateways/index.tsx
@@ -108,7 +108,7 @@ const Gateways = () => {
     }),
     columnHelper.accessor('totalStake', {
       id: 'totalStake',
-      header: 'Total Stake',
+      header: `Total Stake (${IO_LABEL})`,
       sortDescFirst: true,
       cell: ({ row }) => (
         <Tooltip

--- a/src/pages/Gateways/index.tsx
+++ b/src/pages/Gateways/index.tsx
@@ -102,7 +102,7 @@ const Gateways = () => {
     }),
     columnHelper.accessor('start', {
       id: 'start',
-      header: 'Start',
+      header: 'Join Date',
       sortDescFirst: true,
       cell: ({ row }) => formatDate(row.original.start),
     }),

--- a/src/pages/Gateways/index.tsx
+++ b/src/pages/Gateways/index.tsx
@@ -53,7 +53,9 @@ const Gateways = () => {
               .toIO()
               .valueOf(),
             status: gateway.status,
-            rewardRatio: gateway.settings.delegateRewardShareRatio,
+            rewardRatio: gateway.settings.allowDelegatedStaking
+              ? gateway.settings.delegateRewardShareRatio
+              : -1,
             streak:
               gateway.stats.failedConsecutiveEpochs > 0
                 ? -gateway.stats.failedConsecutiveEpochs
@@ -136,7 +138,8 @@ const Gateways = () => {
       id: 'rewardRatio',
       header: 'Reward Share Ratio',
       sortDescFirst: true,
-      cell: ({ row }) => `${row.original.rewardRatio}%`,
+      cell: ({ row }) =>
+        row.original.rewardRatio >= 0 ? `${row.original.rewardRatio}%` : 'N/A',
     }),
     columnHelper.accessor('streak', {
       id: 'streak',

--- a/src/pages/Gateways/index.tsx
+++ b/src/pages/Gateways/index.tsx
@@ -119,7 +119,7 @@ const Gateways = () => {
                 {IO_LABEL}
               </div>
               <div className="mt-1">
-                Total Delegated Stake:{' '}
+                Delegated Stake:{' '}
                 {formatWithCommas(row.original.totalDelegatedStake)} {IO_LABEL}
               </div>
             </div>

--- a/src/pages/Staking/DelegateStakeTable.tsx
+++ b/src/pages/Staking/DelegateStakeTable.tsx
@@ -6,7 +6,7 @@ import Tooltip from '@src/components/Tooltip';
 import { InfoIcon } from '@src/components/icons';
 import ConnectModal from '@src/components/modals/ConnectModal';
 import StakingModal from '@src/components/modals/StakingModal';
-import { EAY_TOOLTIP_TEXT } from '@src/constants';
+import { EAY_TOOLTIP_TEXT, IO_LABEL } from '@src/constants';
 import useGateways from '@src/hooks/useGateways';
 import useProtocolBalance from '@src/hooks/useProtocolBalance';
 import { useGlobalState } from '@src/store';
@@ -104,7 +104,7 @@ const DelegateStake = () => {
     }),
     columnHelper.accessor('totalDelegatedStake', {
       id: 'totalDelegatedStake',
-      header: 'Total Stake',
+      header: `Total Stake (${IO_LABEL})`,
       sortDescFirst: true,
     }),
     columnHelper.accessor('failedConsecutiveEpochs', {

--- a/src/pages/Staking/DelegateStakeTable.tsx
+++ b/src/pages/Staking/DelegateStakeTable.tsx
@@ -6,7 +6,11 @@ import Tooltip from '@src/components/Tooltip';
 import { InfoIcon } from '@src/components/icons';
 import ConnectModal from '@src/components/modals/ConnectModal';
 import StakingModal from '@src/components/modals/StakingModal';
-import { EAY_TOOLTIP_TEXT, IO_LABEL } from '@src/constants';
+import {
+  EAY_TOOLTIP_FORMULA,
+  EAY_TOOLTIP_TEXT,
+  IO_LABEL,
+} from '@src/constants';
 import useGateways from '@src/hooks/useGateways';
 import useProtocolBalance from '@src/hooks/useProtocolBalance';
 import { useGlobalState } from '@src/store';
@@ -123,7 +127,14 @@ const DelegateStake = () => {
       header: () => (
         <div className="flex gap-[4px]">
           EAY
-          <Tooltip message={EAY_TOOLTIP_TEXT}>
+          <Tooltip
+            message={
+              <div>
+                <p>{EAY_TOOLTIP_TEXT}</p>
+                <p className="mt-4">{EAY_TOOLTIP_FORMULA}</p>
+              </div>
+            }
+          >
             <InfoIcon className="h-full" />
           </Tooltip>
         </div>
@@ -183,9 +194,9 @@ const DelegateStake = () => {
         />
       )}
 
-        {isConnectModalOpen && (
-          <ConnectModal onClose={() => setIsConnectModalOpen(false)} />
-        )}
+      {isConnectModalOpen && (
+        <ConnectModal onClose={() => setIsConnectModalOpen(false)} />
+      )}
     </div>
   );
 };

--- a/src/pages/Staking/DelegateStakeTable.tsx
+++ b/src/pages/Staking/DelegateStakeTable.tsx
@@ -26,6 +26,8 @@ interface TableData {
   failedConsecutiveEpochs: number;
   rewardRatio: number;
   totalDelegatedStake: number;
+  totalStake: number;
+  operatorStake: number;
   eay: number;
 }
 
@@ -61,9 +63,19 @@ const DelegateStake = () => {
                   failedConsecutiveEpochs:
                     gateway.stats.failedConsecutiveEpochs,
                   rewardRatio: gateway.settings.delegateRewardShareRatio,
+
                   totalDelegatedStake: new mIOToken(gateway.totalDelegatedStake)
                     .toIO()
                     .valueOf(),
+                  operatorStake: new mIOToken(gateway.operatorStake)
+                    .toIO()
+                    .valueOf(),
+                  totalStake: new mIOToken(
+                    gateway.totalDelegatedStake + gateway.operatorStake,
+                  )
+                    .toIO()
+                    .valueOf(),
+
                   eay: calculateGatewayRewards(
                     new mIOToken(protocolBalance).toIO(),
                     Object.keys(gateways).length,
@@ -106,10 +118,28 @@ const DelegateStake = () => {
       sortDescFirst: false,
       cell: ({ row }) => <AddressCell address={row.getValue('owner')} />,
     }),
-    columnHelper.accessor('totalDelegatedStake', {
-      id: 'totalDelegatedStake',
+    columnHelper.accessor('totalStake', {
+      id: 'totalStake',
       header: `Total Stake (${IO_LABEL})`,
       sortDescFirst: true,
+      cell: ({ row }) => (
+        <Tooltip
+          message={
+            <div>
+              <div>
+                Operator Stake: {formatWithCommas(row.original.operatorStake)}{' '}
+                {IO_LABEL}
+              </div>
+              <div className="mt-1">
+                Delegated Stake:{' '}
+                {formatWithCommas(row.original.totalDelegatedStake)} {IO_LABEL}
+              </div>
+            </div>
+          }
+        >
+          {formatWithCommas(row.getValue('totalStake'))}
+        </Tooltip>
+      ),
     }),
     columnHelper.accessor('failedConsecutiveEpochs', {
       id: 'failedConsecutiveEpochs',

--- a/src/pages/Staking/DelegateStakeTable.tsx
+++ b/src/pages/Staking/DelegateStakeTable.tsx
@@ -17,6 +17,7 @@ import { useGlobalState } from '@src/store';
 import { formatWithCommas } from '@src/utils';
 import { calculateGatewayRewards } from '@src/utils/rewards';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { MathJax, MathJaxContext } from 'better-react-mathjax';
 import { useEffect, useState } from 'react';
 
 interface TableData {
@@ -161,7 +162,9 @@ const DelegateStake = () => {
             message={
               <div>
                 <p>{EAY_TOOLTIP_TEXT}</p>
-                <p className="mt-4">{EAY_TOOLTIP_FORMULA}</p>
+                <p className="mt-4"> 
+                  <MathJax>{EAY_TOOLTIP_FORMULA}</MathJax>
+                </p>
               </div>
             }
           >

--- a/src/pages/Staking/DelegateStakeTable.tsx
+++ b/src/pages/Staking/DelegateStakeTable.tsx
@@ -17,7 +17,7 @@ import { useGlobalState } from '@src/store';
 import { formatWithCommas } from '@src/utils';
 import { calculateGatewayRewards } from '@src/utils/rewards';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { MathJax, MathJaxContext } from 'better-react-mathjax';
+import { MathJax } from 'better-react-mathjax';
 import { useEffect, useState } from 'react';
 
 interface TableData {
@@ -162,9 +162,7 @@ const DelegateStake = () => {
             message={
               <div>
                 <p>{EAY_TOOLTIP_TEXT}</p>
-                <p className="mt-4"> 
-                  <MathJax>{EAY_TOOLTIP_FORMULA}</MathJax>
-                </p>
+                <MathJax className="mt-4">{EAY_TOOLTIP_FORMULA}</MathJax>
               </div>
             }
           >

--- a/yarn.lock
+++ b/yarn.lock
@@ -4266,6 +4266,13 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
+better-react-mathjax@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/better-react-mathjax/-/better-react-mathjax-2.0.3.tgz#202dc6fe5c7263278f2491516f43f70ba188122f"
+  integrity sha512-wfifT8GFOKb1TWm2+E50I6DJpLZ5kLbch283Lu043EJtwSv0XvZDjr4YfR4d2MjAhqP6SH4VjjrKgbX8R00oCQ==
+  dependencies:
+    mathjax-full "^3.2.2"
+
 bigint-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
@@ -4840,6 +4847,11 @@ commander@12.1.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
   integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
+commander@9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
+  integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
 
 commander@^2.20.3:
   version "2.20.3"
@@ -5882,6 +5894,11 @@ eslint@^8.56.0:
     optionator "^0.9.3"
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
+
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
@@ -8134,6 +8151,16 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
+mathjax-full@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/mathjax-full/-/mathjax-full-3.2.2.tgz#43f02e55219db393030985d2b6537ceae82f1fa7"
+  integrity sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==
+  dependencies:
+    esm "^3.2.25"
+    mhchemparser "^4.1.0"
+    mj-context-menu "^0.6.1"
+    speech-rule-engine "^4.0.6"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8178,6 +8205,11 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+mhchemparser@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/mhchemparser/-/mhchemparser-4.2.1.tgz#d73982e66bc06170a85b1985600ee9dabe157cb0"
+  integrity sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==
 
 micromatch@4.0.6:
   version "4.0.6"
@@ -8303,6 +8335,11 @@ mixme@^0.5.1:
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.5.10.tgz#d653b2984b75d9018828f1ea333e51717ead5f51"
   integrity sha512-5H76ANWinB1H3twpJ6JY8uvAtpmFvHNArpilJAjXRKXSDDLPIMoZArw5SH0q9z+lLs8IrMw7Q2VWpWimFKFT1Q==
+
+mj-context-menu@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/mj-context-menu/-/mj-context-menu-0.6.1.tgz#a043c5282bf7e1cf3821de07b13525ca6f85aa69"
+  integrity sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==
 
 mkdirp@~0.5.1:
   version "0.5.6"
@@ -9866,6 +9903,15 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz#887da8aa73218e51a1d917502d79863161a93f9c"
   integrity sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==
 
+speech-rule-engine@^4.0.6:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz#b655dacbad3dae04acc0f7665e26ef258397dd09"
+  integrity sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==
+  dependencies:
+    commander "9.2.0"
+    wicked-good-xpath "1.3.0"
+    xmldom-sre "0.1.31"
+
 split2@^3.0.0, split2@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
@@ -10887,6 +10933,11 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
+wicked-good-xpath@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz#81b0e95e8650e49c94b22298fff8686b5553cf6c"
+  integrity sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==
+
 winston-transport@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.7.0.tgz#e302e6889e6ccb7f383b926df6936a5b781bd1f0"
@@ -11006,6 +11057,11 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmldom-sre@0.1.31:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/xmldom-sre/-/xmldom-sre-0.1.31.tgz#10860d5bab2c603144597d04bf2c4980e98067f4"
+  integrity sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==
 
 xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
1. Gateways Explorer Tab: Reward Share Ratio column should say “N/A” if delegated staking is not enabled.
2. Add “Stake Now” button on gateway details page if delegated staking is enabled. Button location next to “delegated stake enabled”.
3. Set max height of modals to height of window and scroll contents of modal if necessary (keeps close button always accessible)
4. Gateways Tab: ”Start” column rename to “Join date”
5. Gateway Details: ”Start time” rename to “Join date”
6. Gateways Tab: Stake column should label “tIO” (IO at mainnet), e.g., Total Stake (tIO)
7. Gateways Tab: Remove “Total” from “Total Delegated Stake” on the hover-over
8. Gateway Details: Reward share ratio add % after value.
9. EAY Tooltip: add formula for EAY
10. Delegated Stake Tab: Replace values in “Total Stake” with…. total stake similar to gateways tab (i.e., with tooltip and formatted with commas). 