### PR TITLE
fix(observe): set `Accept-Encoding` header when fetching arns data, update reference gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Updated header style of cards
+* Observations: Updated to use arweave.net for reference domain when generating observation report
 
 ## [1.3.0] - 2024-10-21
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,3 +54,8 @@ export const EAY_TOOLTIP_FORMULA =
 
 export const OPERATOR_EAY_TOOLTIP_FORMULA =
   '\\(EAY = \\frac{OperatorRewardsPerEpoch}{OperatorStake} * EpochsPerYear\\)';
+
+// OBSERVATION ASSESSMENT CONSTANTS
+export const NAME_PASS_THRESHOLD = 0.8;
+export const REFERENCE_GATEWAY_FQDN =
+  process.env.VITE_REFERENCE_GATEWAY_FQDN ?? 'arweave.net';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -104,6 +104,10 @@ export const fetchWithTimeout = async (resource:string, options?:RequestInit, ti
 
   const response = await fetch(resource, {
     ...options,
+    headers: {
+      ...options?.headers,
+      'Accept-Encoding': 'identity'
+    },
     signal: controller.signal  
   });
   clearTimeout(id);

--- a/src/utils/observations.ts
+++ b/src/utils/observations.ts
@@ -1,12 +1,9 @@
 /* Based on code by elliotsayes from https://github.com/elliotsayes/gateway-explorer */
 
 import { AoGatewayWithAddress } from '@ar.io/sdk/web';
-import { log } from '@src/constants';
+import { log, NAME_PASS_THRESHOLD, REFERENCE_GATEWAY_FQDN } from '@src/constants';
 import { ArNSAssessment, Assessment, OwnershipAssessment } from '@src/types';
 import { arrayBufferToBase64Url, fetchWithTimeout } from '.';
-
-const NAME_PASS_THRESHOLD = 0.8;
-const REFERENCE_GATEWAY_FQDN = 'arweave.net'; 
 
 export const assessOwnership = async (
   gateway: AoGatewayWithAddress,

--- a/src/utils/observations.ts
+++ b/src/utils/observations.ts
@@ -6,7 +6,7 @@ import { ArNSAssessment, Assessment, OwnershipAssessment } from '@src/types';
 import { arrayBufferToBase64Url, fetchWithTimeout } from '.';
 
 const NAME_PASS_THRESHOLD = 0.8;
-const REFERENCE_GATEWAY_FQDN = 'ar-io.dev';
+const REFERENCE_GATEWAY_FQDN = 'arweave.net'; 
 
 export const assessOwnership = async (
   gateway: AoGatewayWithAddress,


### PR DESCRIPTION
Gateways may use CDNs to serve data. Depending on their configuration, those CDNs often return compressed data with different hashes, which results in failed observations even if the uncompressed data matches. This change ensures all arns requests fetch raw data from the respective gateway without compression via the `Accept-Encoding: identity` header.

Related PR: https://github.com/ar-io/ar-io-observer/pull/53

Additionally, changing the `REFERENCE_GATEWAY_FQDN` to match r19 of the observers to `arweave.net` - https://github.com/ar-io/ar-io-observer/blob/develop/src/config.ts#L62-L65. This may be useful as an environment variable at build time. 