### PR TITLE
feat(PE-7469): update @ar.io/sdk deps for historical epoch retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Signing with ArConnect now uses signDataItem API, providing a more informed signing experience.
+
 ## [1.7.0] - 2024-12-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "deploy": "yarn build && permaweb-deploy --ant-process ${DEPLOY_ANT_PROCESS_ID}"
   },
   "dependencies": {
-    "@ar.io/sdk": "3.3.0-alpha.11",
+    "@ar.io/sdk": "^3.3.0-alpha.12",
     "@fontsource/rubik": "^5.0.19",
     "@headlessui/react": "^2.2.0",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "deploy": "yarn build && permaweb-deploy --ant-process ${DEPLOY_ANT_PROCESS_ID}"
   },
   "dependencies": {
-    "@ar.io/sdk": "3.0.1-alpha.1",
+    "@ar.io/sdk": "^3.3.0-alpha.2",
     "@fontsource/rubik": "^5.0.19",
     "@headlessui/react": "^2.2.0",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/src/hooks/useEpochs.ts
+++ b/src/hooks/useEpochs.ts
@@ -2,7 +2,10 @@ import { useGlobalState } from '@src/store';
 import { getEpoch } from '@src/store/db';
 import { useQuery } from '@tanstack/react-query';
 
-/** Returns last 14 epochs */
+// TODO: this could be a parameter provided by the user now
+const HISTORICAL_EPOCHS_TO_FETCH = 13;
+
+/** Returns last EPOCHS_TO_FETCH epochs */
 const useEpochs = () => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
   const startEpoch = useGlobalState((state) => state.currentEpoch);
@@ -15,11 +18,11 @@ const useEpochs = () => {
       }
 
       const additionalEpochs = await Promise.all(
-        Array.from({ length: 13 }, (_, index) => startEpoch.epochIndex - index - 1)
+        Array.from({ length: HISTORICAL_EPOCHS_TO_FETCH }, (_, index) => startEpoch.epochIndex - index - 1)
           .map(epochIndex => getEpoch(arIOReadSDK, epochIndex))
       );      
 
-      return [startEpoch, ...additionalEpochs.filter(e => e !== undefined)];
+      return [startEpoch, ...additionalEpochs.filter((e: any) => e !== undefined)];
     },
   });
 

--- a/src/hooks/useRewardsEarned.ts
+++ b/src/hooks/useRewardsEarned.ts
@@ -13,16 +13,16 @@ const useRewardsEarned = (walletAddress?: string) => {
 
   useEffect(() => {
     if (epochs && walletAddress) {
-      const sorted = epochs.sort((a, b) => a.epochIndex - b.epochIndex);
+      const sorted = epochs.sort((a, b) => (a?.epochIndex || 0) - (b?.epochIndex || 0));
       const previousEpoch = sorted[sorted.length - 2];
       const previousEpochDistributed =
-        previousEpoch.distributions.rewards.distributed;
+        previousEpoch?.distributions.rewards.distributed;
       const previousEpochRewards = previousEpochDistributed
         ? previousEpochDistributed[walletAddress] || 0
         : 0;
 
       const totalForPastAvailableEpochs = epochs.reduce((acc, epoch) => {
-        const distributed = epoch.distributions.rewards.distributed;
+        const distributed = epoch?.distributions.rewards.distributed;
         return acc + (distributed ? distributed[walletAddress] || 0 : 0);
       }, 0);
 

--- a/src/pages/Gateway/SnitchRow.tsx
+++ b/src/pages/Gateway/SnitchRow.tsx
@@ -34,7 +34,7 @@ const ReportedOnByCard = ({ gateway }: { gateway?: AoGatewayWithAddress }) => {
         const entries = observers.map<ReportedOnByEntry>((observerId) => {
           return {
             observerId,
-            reportId: selectedEpoch.observations.reports[observerId],
+            reportId: selectedEpoch?.observations.reports[observerId],
           };
         });
         setFailureObservers(entries);

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,10 +35,10 @@
     plimit-lit "^3.0.1"
     warp-contracts "1.4.45"
 
-"@ar.io/sdk@3.3.0-alpha.11":
-  version "3.3.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.3.0-alpha.11.tgz#4ecb67a7f869d989b46b24d7922e119cfef9577e"
-  integrity sha512-hxMTRQtW0ZXIUjRDKrbbtdMD8KxcPhH46BRShc8KteVPkv6BUrWfvfIdx8Lu08QQmWnVpC2xFdq3FqexpC3N5g==
+"@ar.io/sdk@^3.3.0-alpha.12":
+  version "3.3.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.3.0-alpha.12.tgz#73464e6834eb430946062768d69310d470095208"
+  integrity sha512-MiVze8ed2GNsH16NJDOCLrKrnmh6v1nTRZUhPK9YS3m3tUMYeu7zOnDxQooaDjduwH+d5CI1jpOYOncyTT+skw==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,15 +35,15 @@
     plimit-lit "^3.0.1"
     warp-contracts "1.4.45"
 
-"@ar.io/sdk@3.0.1-alpha.1":
-  version "3.0.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.0.1-alpha.1.tgz#4c0ccd5df8628039342be611125fba7061d301b4"
-  integrity sha512-XKvDA3uygPskb++QPkByBfrIfNxvsiKRHO35Sy0eZ8GevnBuc2TKNVCtZVYKn2A8zduD7Jx9egFQBUw/XN/qtA==
+"@ar.io/sdk@^3.3.0-alpha.2":
+  version "3.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.3.0-alpha.2.tgz#2a6add311fad34b2e3f370a7e6c0d919f9897f0d"
+  integrity sha512-fhTTLyvhFBoLP3uAt/jNvvne5NneexHLyN0obeFdX8i0Dd2Gah95i4c9o+dmJBEqOXSG3XFr5hbephtsJq1zVg==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
     arweave "1.14.4"
-    axios "1.7.8"
+    axios "1.7.9"
     axios-retry "^4.3.0"
     commander "^12.1.0"
     eventemitter3 "^5.0.1"
@@ -4548,10 +4548,10 @@ axios@1.7.2:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@1.7.8:
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.8.tgz#1997b1496b394c21953e68c14aaa51b7b5de3d6e"
-  integrity sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==
+axios@1.7.9:
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
The new version allows for fetching historical epoch data > 14 epochs. This parameter is hard coded, but could now be exposed on the frontend.

You can see the updated requests to gql in the network tab when loading the Dashboard.

<img width="1786" alt="image" src="https://github.com/user-attachments/assets/c76b5f9b-81c6-4659-8168-2ad6a4699e92" />