### PR TITLE
fix(ario): update other hooks when process id changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "deploy": "yarn build && permaweb-deploy --ant-process ${DEPLOY_ANT_PROCESS_ID}"
   },
   "dependencies": {
-    "@ar.io/sdk": "^3.5.0-alpha.1",
+    "@ar.io/sdk": "^3.5.1-alpha.2",
     "@fontsource/rubik": "^5.0.19",
     "@headlessui/react": "^2.2.0",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/src/hooks/useArNSStats.ts
+++ b/src/hooks/useArNSStats.ts
@@ -14,9 +14,9 @@ export type ArNSStats = {
 const useArNSStats = () => {
   const arioReadSDK = useGlobalState((state) => state.arIOReadSDK);
   const currentEpoch = useGlobalState((state) => state.currentEpoch);
-
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const res = useQuery<ArNSStats>({
-    queryKey: ['arNSStats', arioReadSDK, currentEpoch],
+    queryKey: ['arNSStats', arioReadSDK, currentEpoch, arioProcessId],
     queryFn: async () => {
       if (!arioReadSDK) throw new Error('arIOReadSDK not initialized');
       if (!currentEpoch) throw new Error('currentEpoch not initialized');
@@ -33,7 +33,7 @@ const useArNSStats = () => {
         ...currentEpoch.arnsStats
       };
     },
-    enabled: !!arioReadSDK && !!currentEpoch,
+    enabled: !!arioReadSDK && !!currentEpoch && !!arioProcessId,
   });
   return res;
 };

--- a/src/hooks/useBalances.ts
+++ b/src/hooks/useBalances.ts
@@ -10,9 +10,9 @@ const useBalances = (walletAddress?: AoAddress) => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
   const arweave = useGlobalState((state) => state.arweave);
   const blockHeight = useGlobalState((state) => state.blockHeight);
-
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const res = useQuery<Balances>({
-    queryKey: ['balances', arIOReadSDK, arweave, walletAddress, blockHeight],
+    queryKey: ['balances', arIOReadSDK, arweave, walletAddress, blockHeight, arioProcessId],
     queryFn: async () => {
       if (!walletAddress || !arweave || !arIOReadSDK) {
         throw new Error(
@@ -31,7 +31,7 @@ const useBalances = (walletAddress?: AoAddress) => {
       return { ar: arBalance, ario: ioBalance };
     },
     staleTime: 5 * 60 * 1000,
-    enabled: !!walletAddress && !!arweave && !!arIOReadSDK,
+    enabled: !!walletAddress && !!arweave && !!arIOReadSDK && !!arioProcessId,
   });
 
   return res;

--- a/src/hooks/useEpochs.ts
+++ b/src/hooks/useEpochs.ts
@@ -7,12 +7,13 @@ const HISTORICAL_EPOCHS_TO_FETCH = 13;
 
 /** Returns last EPOCHS_TO_FETCH epochs */
 const useEpochs = () => {
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
   const startEpoch = useGlobalState((state) => state.currentEpoch);
   const networkPortalDB = useGlobalState((state) => state.networkPortalDB);
 
   const queryResults = useQuery({
-    queryKey: ['epochs', arIOReadSDK, startEpoch],
+    queryKey: ['epochs', arIOReadSDK, startEpoch, arioProcessId],
     queryFn: async () => {
       if (!arIOReadSDK || startEpoch === undefined) {
         throw new Error('arIOReadSDK or startEpoch not available');

--- a/src/hooks/useGateway.ts
+++ b/src/hooks/useGateway.ts
@@ -9,9 +9,10 @@ const useGateway = ({
   ownerWalletAddress?: string;
 }) => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
 
   const queryResults = useQuery({
-    queryKey: ['gateway', ownerWalletAddress || '', arIOReadSDK],
+    queryKey: ['gateway', ownerWalletAddress || '', arIOReadSDK, arioProcessId],
     queryFn: () => {
       if (ownerWalletAddress === undefined) {
         return Promise.reject(

--- a/src/hooks/useGateways.ts
+++ b/src/hooks/useGateways.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 const useGateways = () => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
 
   const fetchAllGateways = async (
     arIOReadSDK: AoARIORead,
@@ -22,7 +23,7 @@ const useGateways = () => {
   };
 
   const queryResults = useQuery({
-    queryKey: ['gateways', arIOReadSDK],
+    queryKey: ['gateways', arIOReadSDK, arioProcessId],
     queryFn: () => {
       if (arIOReadSDK) {
         return fetchAllGateways(arIOReadSDK);

--- a/src/hooks/useGatewaysPerEpoch.ts
+++ b/src/hooks/useGatewaysPerEpoch.ts
@@ -9,10 +9,11 @@ export type GatewayEpochCount = {
 
 const useGatewaysPerEpoch = () => {
   const arioReadSDK = useGlobalState((state) => state.arIOReadSDK);
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const { data: epochs } = useEpochs();
 
   const res = useQuery<Array<GatewayEpochCount>>({
-    queryKey: ['gatewaysPerEpoch', epochs, arioReadSDK],
+    queryKey: ['gatewaysPerEpoch', epochs, arioReadSDK, arioProcessId],
     queryFn: () => {
       if (!arioReadSDK || !epochs) {
         throw new Error('arIOReadSDK not initialized or epochs not available');

--- a/src/hooks/useLogo.ts
+++ b/src/hooks/useLogo.ts
@@ -4,9 +4,10 @@ import { useQuery } from '@tanstack/react-query';
 
 const useLogo = ({ primaryName }: { primaryName?: string }) => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
 
   const queryResults = useQuery({
-    queryKey: ['logo', primaryName, arIOReadSDK],
+    queryKey: ['logo', primaryName, arIOReadSDK, arioProcessId],
     queryFn: async () => {
       if (!primaryName || !arIOReadSDK) {
         throw new Error('Primary Name or ArIO Read SDK not available');

--- a/src/hooks/useObservers.ts
+++ b/src/hooks/useObservers.ts
@@ -4,9 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 
 const useObservers = (epoch?: AoEpochData) => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
-
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const queryResults = useQuery({
-    queryKey: ['prescribedObservers', arIOReadSDK, epoch?.epochIndex || -1],
+    queryKey: ['prescribedObservers', arIOReadSDK, epoch?.epochIndex || -1, arioProcessId],
     queryFn: () => {
       if (arIOReadSDK && epoch) {
         return arIOReadSDK.getPrescribedObservers(epoch);

--- a/src/hooks/usePrescribedNames.ts
+++ b/src/hooks/usePrescribedNames.ts
@@ -7,9 +7,9 @@ const usePrescribedNames = () => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
 
   const currentEpoch = useGlobalState((state) => state.currentEpoch);
-
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const queryResults = useQuery({
-    queryKey: ['prescribedNames', arIOReadSDK, currentEpoch?.epochIndex || -1],
+    queryKey: ['prescribedNames', arIOReadSDK, currentEpoch?.epochIndex || -1, arioProcessId],
     queryFn: () => {
       if (arIOReadSDK && currentEpoch) {
         return arIOReadSDK.getPrescribedNames(currentEpoch).catch((e) => {
@@ -24,7 +24,7 @@ const usePrescribedNames = () => {
       // log error
       throw new Error('arIOReadSDK or currentEpoch not available');
     },
-    enabled: !!arIOReadSDK && !!currentEpoch,
+    enabled: !!arIOReadSDK && !!currentEpoch && !!arioProcessId,
   });
 
   return queryResults;

--- a/src/hooks/usePrimaryName.ts
+++ b/src/hooks/usePrimaryName.ts
@@ -3,9 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 
 const usePrimaryName = (walletAddress?: string) => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
 
   const res = useQuery({
-    queryKey: ['primaryName', walletAddress, arIOReadSDK],
+    queryKey: ['primaryName', walletAddress, arIOReadSDK, arioProcessId],
     queryFn: async () => {
       if (!walletAddress || !arIOReadSDK) {
         throw new Error('Wallet Address or SDK not available');

--- a/src/hooks/useRedelegationFee.ts
+++ b/src/hooks/useRedelegationFee.ts
@@ -3,9 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 
 const useRedelegationFee = (walletAddress?: string) => {
   const arioReadSDK = useGlobalState((state) => state.arIOReadSDK);
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
 
   const res = useQuery({
-    queryKey: ['redelegationFee', walletAddress, arioReadSDK],
+    queryKey: ['redelegationFee', walletAddress, arioReadSDK, arioProcessId],
     queryFn: async () => {
       if (!arioReadSDK) throw new Error('arIOReadSDK not initialized');
       if (!walletAddress) throw new Error('walletAddress not initialized');

--- a/src/hooks/useReports.ts
+++ b/src/hooks/useReports.ts
@@ -16,14 +16,14 @@ export interface ReportTransactionData {
 
 const useReports = (ownerId?: string, gateway?: AoGateway) => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
-
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const observerAddress = gateway?.observerAddress;
   const gatewayStart = gateway?.startTimestamp;
 
   const { data: epochs } = useEpochs();
 
   const queryResults = useQuery({
-    queryKey: ['reports', ownerId, arIOReadSDK],
+    queryKey: ['reports', ownerId, arIOReadSDK, arioProcessId],
     queryFn: async () => {
       if (
         !arIOReadSDK ||

--- a/src/hooks/useTokenSupply.ts
+++ b/src/hooks/useTokenSupply.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 const useTokenSupply = () => {
   const arioReadSDK = useGlobalState((state) => state.arIOReadSDK);
-
+  const arioProcessId = useGlobalState((state) => state.arioProcessId);
   const res = useQuery({
-    queryKey: ['tokenSupply'],
+    queryKey: ['tokenSupply', arioProcessId],
     queryFn: () => {
       if (!arioReadSDK) throw new Error('arIOReadSDK not initialized');
       return arioReadSDK.getTokenSupply();

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -44,7 +44,10 @@ export const getEpoch = async (networkPortalDB: NetworkPortalDB, arIOReadSDK: Ao
     return epoch;
   }
 
-  const epochData = await arIOReadSDK.getEpoch({ epochIndex });
+  const epochData = await arIOReadSDK.getEpoch({ epochIndex }).catch((e) => {
+    console.error('Error with epoch data fetching:', epochIndex, e);
+    return undefined;
+  });
 
   if (epochData) {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
     plimit-lit "^3.0.1"
     warp-contracts "1.4.45"
 
-"@ar.io/sdk@^3.5.0-alpha.1":
-  version "3.5.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.5.0-alpha.1.tgz#cd66ca714f42a7560cb5f3d783aa45353423bc3c"
-  integrity sha512-ZJLNOTIH5gZnjuHAUoXFI04ZbO6QjsdR5bXRf0u+YvERWVMkJa5gr52P8Jz8vgIC23CHVa36lLjv1zfBEi/pnQ==
+"@ar.io/sdk@^3.5.1-alpha.2":
+  version "3.5.1-alpha.3"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.5.1-alpha.3.tgz#6192db5676d7792cb7fbda99918be08cc223ddaa"
+  integrity sha512-jdmSfBaFe5P3Tsuq8tevc4P2tccTWVyvY11WKPzFC42QIsq1NMIex1CMxycUz+k2PKeEHWIOC7AbwhTPrUv8TA==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
@@ -12121,7 +12121,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12208,7 +12217,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13272,7 +13288,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13285,6 +13301,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
When switching between processes, some panels dont update due to the cache key not be affilited with the selected process id. This updates the one I could track down, there may be more.

Also bumps the SDK.