### PR TITLE
fix(epochs): show actual number of observers per epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.4] - 2025-03-20
+
+### Updated
+
+- Gateway Details page: show actual number of observers per epoch in "Failed by x/y Observers" card 
+
 ## [1.11.3] - 2025-03-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "1.11.3",
+  "version": "1.11.4",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/pages/Gateway/SnitchRow.tsx
+++ b/src/pages/Gateway/SnitchRow.tsx
@@ -20,12 +20,14 @@ const ReportedOnByCard = ({ gateway }: { gateway?: AoGatewayWithAddress | null }
   const [failureObservers, setFailureObservers] = useState<ReportedOnByEntry[]>(
     [],
   );
+  const [totalReportsForEpoch, setTotalReportsForEpoch] = useState<number>(0);
   const observerToGatewayMap = useObserverToGatewayMap();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (epochs) {
       const selectedEpoch = epochs[selectedEpochIndex];
+      setTotalReportsForEpoch(selectedEpoch?.observations?.reports ? Object.keys(selectedEpoch?.observations?.reports).length : 0);
 
       if (gateway) {
         const observers =
@@ -59,7 +61,7 @@ const ReportedOnByCard = ({ gateway }: { gateway?: AoGatewayWithAddress | null }
                 <div className="text-mid">
                   Failed by{' '}
                   <span className="text-red-500">
-                    {failureObservers.length}/50
+                    {failureObservers.length}/{totalReportsForEpoch}
                   </span>{' '}
                   observers
                 </div>


### PR DESCRIPTION
Show the failure count / # of reports submitted to accurately reflect why they failed an epoch.

Instead of 20/50 (which wouldn't be a `FAIL`), correctly show the # of failures/# of actual reports submitted
<img width="723" alt="image" src="https://github.com/user-attachments/assets/b74edacf-60d1-40fa-9baf-662f408328eb" />
