### PR TITLE
feat(epochs): show pass/fail status for epochs on snitch row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.7] - 2025-04-08
+
+## Added
+
+- Gateway: Shows passed/failed for epoch in Reported On By card 
+- Observers: Tooltip added to Observer Performance column to show observed and prescribed counts
+
 ## [1.11.6] - 2025-03-28
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "1.11.6",
+  "version": "1.11.7",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/pages/Gateway/SnitchRow.tsx
+++ b/src/pages/Gateway/SnitchRow.tsx
@@ -5,7 +5,7 @@ import { StatsArrowIcon } from '@src/components/icons';
 import Placeholder from '@src/components/Placeholder';
 import useEpochs from '@src/hooks/useEpochs';
 import useObserverToGatewayMap from '@src/hooks/useObserverToGatewayMap';
-import { NotebookText } from 'lucide-react';
+import { CheckCircleIcon, NotebookText, XCircleIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -64,6 +64,19 @@ const ReportedOnByCard = ({ gateway }: { gateway?: AoGatewayWithAddress | null }
                     {failureObservers.length}/{totalReportsForEpoch}
                   </span>{' '}
                   observers
+                </div>
+              )}
+            </div>
+            <div className="mr-4 flex items-center">
+              {failureObservers.length  <= totalReportsForEpoch / 2? (
+                <div className="flex items-center text-green-500">
+                  <CheckCircleIcon className="mr-1 size-4" />
+                  <span>{selectedEpochIndex === 0 ? 'Passing' : 'Passed'}</span>
+                </div>
+              ) : (
+                <div className="flex items-center text-red-500">
+                  <XCircleIcon className="mr-1 size-4" />
+                  <span>{selectedEpochIndex === 0 ? 'Failing' : 'Failed'}</span>
                 </div>
               )}
             </div>

--- a/src/pages/Gateways/index.tsx
+++ b/src/pages/Gateways/index.tsx
@@ -43,8 +43,7 @@ const Gateways = () => {
     const tableData: Array<TableData> = Object.entries(gateways ?? {}).reduce(
       (acc: Array<TableData>, [owner, gateway]) => {
         const passedEpochCount = gateway.stats.passedEpochCount;
-        const totalEpochCount = (gateway.stats as any).totalEpochCount;
-
+        const totalEpochCount = gateway.stats.totalEpochCount;
         return [
           ...acc,
           {
@@ -179,11 +178,8 @@ const Gateways = () => {
           <Tooltip
             message={
               <div>
-                <div>Passed Epoch Count: {row.original.passedEpochCount}</div>
-                <div className="mt-1">
-                  Total Epoch Participation Count:{' '}
-                  {row.original.totalEpochCount}
-                </div>
+                <div>Passed Epochs: {row.original.passedEpochCount}</div>
+                <div>Total Epochs: {row.original.totalEpochCount}</div>
               </div>
             }
           >

--- a/src/pages/Observers/ObserversTable.tsx
+++ b/src/pages/Observers/ObserversTable.tsx
@@ -2,6 +2,7 @@ import AddressCell from '@src/components/AddressCell';
 import CopyButton from '@src/components/CopyButton';
 import Dropdown from '@src/components/Dropdown';
 import TableView from '@src/components/TableView';
+import Tooltip from '@src/components/Tooltip';
 import useEpochs from '@src/hooks/useEpochs';
 import useGateways from '@src/hooks/useGateways';
 import useObservations from '@src/hooks/useObservations';
@@ -18,6 +19,8 @@ interface TableData {
   observerAddress: string;
   ncw: number;
   successRatio: number;
+  observedEpochs: number;
+  prescribedEpochs: number;
   reportStatus: string;
   failedGateways?: number;
 }
@@ -76,6 +79,8 @@ const ObserversTable = () => {
             gatewayAddress: observer.gatewayAddress,
             observerAddress: observer.observerAddress,
             ncw: observer.normalizedCompositeWeight,
+            observedEpochs: gateway.stats.observedEpochCount + 1, // add one as the contract avoids divide by 0 by incrementing the numerator and denominator by 1 when computing performance ratio
+            prescribedEpochs: gateway.stats.prescribedEpochCount + 1, // add one as the contract avoids divide by 0 by incrementing the numerator and denominator by 1 when computing performance ratio
             successRatio:
               // there will be a period where old epoch notices have the old field, and new epoch notices have the new field, so check both
               observer.observerPerformanceRatio ||
@@ -145,7 +150,18 @@ const ObserversTable = () => {
       id: 'successRatio',
       header: 'Observer Performance',
       sortDescFirst: true,
-      cell: ({ row }) => formatPercentage(row.original.successRatio),
+      cell: ({ row }) => (
+        <Tooltip
+            message={
+              <div>
+                <div>Observed Epochs: {row.original.observedEpochs}</div>
+                <div>Prescribed Epochs: {row.original.prescribedEpochs}</div>
+              </div>
+            }
+        >
+          {`${(row.original.successRatio * 100).toFixed(2)}%`}
+        </Tooltip>
+      ),
     }),
     columnHelper.accessor('reportStatus', {
       id: 'reportStatus',


### PR DESCRIPTION
Shows `passed/failed` for epoch in snitch row

previous epoch:
![image](https://github.com/user-attachments/assets/a26b9ab1-490d-4c68-8a4d-1310c1d084cb)
current epoch:
![image](https://github.com/user-attachments/assets/6923c55e-fc26-499c-add9-79c4743e65d6)


Also adds tool tip for total # of times gateway is prescribed vs. observered
<img width="485" alt="image" src="https://github.com/user-attachments/assets/17223c92-ed8b-425e-ab2a-47ba942409eb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced visual indicators to display gateway performance status with clear, color-coded icons.
  - Updated epoch count labels in tooltips for a cleaner, more intuitive user interface.
  - Enhanced performance metrics tables by providing additional contextual details through refined tooltip displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->