### PR TITLE
chore(deps): bump ar-io-sdk to latest alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.6] - 2025-03-28
+
+## Changed
+
+- Improved error handling when loading historical epoch data
+
 ## [1.11.5] - 2025-03-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deploy": "yarn build && permaweb-deploy --ant-process ${DEPLOY_ANT_PROCESS_ID}"
   },
   "dependencies": {
-    "@ar.io/sdk": "^3.9.1-alpha.1",
+    "@ar.io/sdk": "^3.9.1-alpha.2",
     "@fontsource/rubik": "^5.0.19",
     "@headlessui/react": "^2.2.0",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "1.11.5",
+  "version": "1.11.6",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deploy": "yarn build && permaweb-deploy --ant-process ${DEPLOY_ANT_PROCESS_ID}"
   },
   "dependencies": {
-    "@ar.io/sdk": "3.9.0-alpha.6",
+    "@ar.io/sdk": "^3.9.1-alpha.1",
     "@fontsource/rubik": "^5.0.19",
     "@headlessui/react": "^2.2.0",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/src/hooks/useEpochs.ts
+++ b/src/hooks/useEpochs.ts
@@ -25,12 +25,12 @@ const useEpochs = () => {
           (_, index) => startEpoch.epochIndex - index - 1,
         ).map((epochIndex) =>
           getEpoch(networkPortalDB, arIOReadSDK, epochIndex).then((epoch) => {
-            if (!epoch) {
-              showErrorToast(
-                `Unable to retrieve epoch data for epoch ${epochIndex}.`,
-              );
-            }
             return epoch;
+          }).catch(() => {
+            showErrorToast(
+              `Unable to retrieve epoch data for epoch ${epochIndex}.`,
+            );
+            return undefined;
           }),
         ),
       );

--- a/src/hooks/useRewardsEarned.ts
+++ b/src/hooks/useRewardsEarned.ts
@@ -22,7 +22,7 @@ const useRewardsEarned = (walletAddress?: string) => {
         const previousEpoch = sorted[sorted.length - 2];
         const previousDistribution = previousEpoch?.distributions;
 
-        // rewards are not avialable on current epoch
+        // rewards are not available on current epoch
         const previousEpochDistributed =
           previousDistribution && isDistributedEpochData(previousDistribution)
             ? previousDistribution.rewards.distributed ?? {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,15 +35,15 @@
     plimit-lit "^3.0.1"
     warp-contracts "1.4.45"
 
-"@ar.io/sdk@3.9.0-alpha.6":
-  version "3.9.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.9.0-alpha.6.tgz#5e9143b8b5e3bc2fc644d090647e9851ddbefce8"
-  integrity sha512-HDyvjPo0fqS3/YmlwwMZLOwumBk+zwVdGPOK+2niSEAoZTq4fnQWiRUmDthfpZjb9lTJlvZuMrN9814HefGgHw==
+"@ar.io/sdk@^3.9.1-alpha.1":
+  version "3.9.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.9.1-alpha.1.tgz#371824dab6e042929cb5dcfc17dc491c2b1c595e"
+  integrity sha512-sw2JprN87YKKGP8/Frh2RiDf/qZL+mRqgc0LUv0Xg4Ez6ES/OeiNFiKk/QJWOCqwS1S0kzHNoG/PXikqAbRLaQ==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
     arweave "1.15.5"
-    axios "1.7.9"
+    axios "1.8.4"
     axios-retry "^4.3.0"
     commander "^12.1.0"
     eventemitter3 "^5.0.1"
@@ -5428,10 +5428,10 @@ axios@1.7.2:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
-  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
+axios@1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -11472,7 +11472,16 @@ string-argv@0.3.2:
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11559,7 +11568,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12589,7 +12605,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12602,6 +12618,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,10 +35,10 @@
     plimit-lit "^3.0.1"
     warp-contracts "1.4.45"
 
-"@ar.io/sdk@^3.9.1-alpha.1":
-  version "3.9.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.9.1-alpha.1.tgz#371824dab6e042929cb5dcfc17dc491c2b1c595e"
-  integrity sha512-sw2JprN87YKKGP8/Frh2RiDf/qZL+mRqgc0LUv0Xg4Ez6ES/OeiNFiKk/QJWOCqwS1S0kzHNoG/PXikqAbRLaQ==
+"@ar.io/sdk@^3.9.1-alpha.2":
+  version "3.9.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.9.1-alpha.2.tgz#4b0964fd51ae3e95c52575ad4d7537725690e9a6"
+  integrity sha512-NYU3VrdMPtzJBS2t9LIcwYI3iBYVetRveKr8bhY0ei7zpq0NysmKUiyYzqw/YapnytUJbCEmWtwRzjaFkzCVxQ==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"


### PR DESCRIPTION
This version throws the error if it fails to fetch historical epochs, matching the behavior for if it is not able to find the current epoch.

Related SDK: https://github.com/ar-io/ar-io-sdk/pull/445/commits/b1bb0247349f33aed86e5a01c074b1c25256d66e