### PR TITLE
fix(observers): default observations to use ar-io.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.8] - 2025-05-15
+
+### Changed
+
+- Observations: Updated gateway reference host to ar-io.net
+
 ## [1.11.7] - 2025-04-08
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "1.11.7",
+  "version": "1.11.8",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export const AO_CU_URL = import.meta.env.VITE_AO_CU_URL || 'https://cu.ardrive.i
 export const DEFAULT_ARWEAVE_PROTOCOL =
   import.meta.env.VITE_GATEWAY_PROTOCOL ?? 'https';
 export const DEFAULT_ARWEAVE_HOST =
-  import.meta.env.VITE_GATEWAY_HOST ?? 'ar-io.net';
+  import.meta.env.VITE_GATEWAY_HOST ?? 'arweave.net'; // TODO: likely should change to ar-io.net depending on how this is used throughout the app
 
 export const DEFAULT_ARWEAVE_GQL_ENDPOINT =
   import.meta.env.VITE_ARWEAVE_GQL_ENDPOINT ??
@@ -62,7 +62,7 @@ export const OPERATOR_EAY_TOOLTIP_FORMULA =
 // OBSERVATION ASSESSMENT CONSTANTS
 export const NAME_PASS_THRESHOLD = 0.8;
 export const REFERENCE_GATEWAY_FQDN =
-  import.meta.env.VITE_REFERENCE_GATEWAY_FQDN ?? 'arweave.net';
+  import.meta.env.VITE_REFERENCE_GATEWAY_FQDN ?? 'ar-io.net';
 
 export const REDELEGATION_FEE_TOOLTIP_TEXT =
   'Redelegation fees are assessed at 10% per redelegation performed since the last fee reset, up to 60%. Fees are reset when no redelegations are performed in the last 7 days.';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export const AO_CU_URL = import.meta.env.VITE_AO_CU_URL || 'https://cu.ardrive.i
 export const DEFAULT_ARWEAVE_PROTOCOL =
   import.meta.env.VITE_GATEWAY_PROTOCOL ?? 'https';
 export const DEFAULT_ARWEAVE_HOST =
-  import.meta.env.VITE_GATEWAY_HOST ?? 'arweave.net';
+  import.meta.env.VITE_GATEWAY_HOST ?? 'ar-io.net';
 
 export const DEFAULT_ARWEAVE_GQL_ENDPOINT =
   import.meta.env.VITE_ARWEAVE_GQL_ENDPOINT ??


### PR DESCRIPTION
As of r34 observers check gateways against ar-io.net by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the default gateway host for observations to ar-io.net, with environment overrides remaining available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->