### PR TITLE
Add mobile friendly view

### DIFF
--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -1,3 +1,4 @@
+import useIsMobile from '@src/hooks/useIsMobile';
 import {
   ColumnDef,
   ColumnSort,
@@ -29,73 +30,80 @@ const TableView = <T, S>({
   shortTable?: boolean;
 }) => {
   const [sorting, setSorting] = useState<SortingState>([defaultSortingState]);
+  const isMobile = useIsMobile();
+  const [page, setPage] = useState(0);
 
   const table = useReactTable({
     columns,
     data,
     getCoreRowModel: getCoreRowModel<T>(),
-    getSortedRowModel: getSortedRowModel(), //provide a sorting row model
+    getSortedRowModel: getSortedRowModel(),
     state: { sorting },
     onSortingChange: setSorting,
   });
 
-  const maxHeightRemClass = shortTable 
-    ? `max-h-[16rem]`
-    : undefined;
+  const maxHeightRemClass = shortTable ? `max-h-[16rem]` : undefined;
+
+  const rows = table.getRowModel().rows;
+  const pageCount = Math.ceil(rows.length / 10);
+  const pagedRows = isMobile ? rows.slice(page * 10, page * 10 + 10) : rows;
 
   return (
     <>
-      <div className={`overflow-x-auto scrollbar ${maxHeightRemClass}`}>
-        <table className="w-full table-auto border-x border-b border-grey-500">
-          <thead className="sticky top-0 z-10 bg-containerL0 text-xs text-low">
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  const sortState = header.column.getIsSorted();
-                  return (
-                    <th key={header.id} className="py-2 pl-6">
-                      <button
-                        className="flex items-center gap-1 text-left"
-                        onClick={() => {
-                          setSorting([
-                            {
-                              id: header.column.id,
-                              desc: sortState
-                                ? sortState === 'desc'
-                                  ? false
-                                  : true
-                                : header.column.columnDef.sortDescFirst ?? true,
-                            },
-                          ]);
-                        }}
-                      >
-                        {flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                        {sortState ? (
-                          sortState === 'desc' ? (
-                            <SortDesc />
+      {!isMobile && (
+        <div className={`overflow-x-auto scrollbar ${maxHeightRemClass}`}>
+          <table className="w-full table-auto border-x border-b border-grey-500">
+            <thead className="sticky top-0 z-10 bg-containerL0 text-xs text-low">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    const sortState = header.column.getIsSorted();
+                    return (
+                      <th key={header.id} className="py-2 pl-6">
+                        <button
+                          className="flex items-center gap-1 text-left"
+                          onClick={() => {
+                            setSorting([
+                              {
+                                id: header.column.id,
+                                desc: sortState
+                                  ? sortState === 'desc'
+                                    ? false
+                                    : true
+                                  : header.column.columnDef.sortDescFirst ??
+                                    true,
+                              },
+                            ]);
+                          }}
+                        >
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                          {sortState ? (
+                            sortState === 'desc' ? (
+                              <SortDesc />
+                            ) : (
+                              <SortAsc />
+                            )
                           ) : (
-                            <SortAsc />
-                          )
-                        ) : (
-                          <div className="w-4" />
-                        )}
-                      </button>
-                    </th>
-                  );
-                })}
-              </tr>
-            ))}
-          </thead>
-          {!isLoading && (
-            <tbody className="overflow-y-auto text-sm">
-              {table.getRowModel().rows.map((row) => {
-                return (
+                            <div className="w-4" />
+                          )}
+                        </button>
+                      </th>
+                    );
+                  })}
+                </tr>
+              ))}
+            </thead>
+            {!isLoading && (
+              <tbody className="overflow-y-auto text-sm">
+                {pagedRows.map((row) => (
                   <tr
                     key={row.id}
-                    className={`border-t border-grey-500 text-low *:py-4 *:pl-6 ${onRowClick ? 'cursor-pointer' : ''}`}
+                    className={`border-t border-grey-500 text-low *:py-4 *:pl-6${
+                      onRowClick ? ' cursor-pointer' : ''
+                    }`}
                     onClick={
                       onRowClick ? () => onRowClick(row.original) : undefined
                     }
@@ -109,12 +117,58 @@ const TableView = <T, S>({
                       </td>
                     ))}
                   </tr>
-                );
-              })}
-            </tbody>
-          )}
-        </table>
-      </div>
+                ))}
+              </tbody>
+            )}
+          </table>
+        </div>
+      )}
+      {isMobile && !isLoading && (
+        <div className="space-y-4">
+          {pagedRows.map((row) => (
+            <div
+              key={row.id}
+              className={`rounded-lg border border-grey-500 p-4 text-sm text-low${
+                onRowClick ? ' cursor-pointer' : ''
+              }`}
+              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+            >
+              {row.getAllCells().map((cell) => (
+                <div key={cell.id} className="mb-1 flex justify-between gap-2">
+                  <div className="text-xs text-low">
+                    {flexRender(
+                      cell.column.columnDef.header,
+                      cell.getContext(),
+                    )}
+                  </div>
+                  <div className="text-right">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+          <div className="flex justify-center gap-4 pt-2">
+            <button
+              disabled={page === 0}
+              className="text-xs disabled:opacity-50"
+              onClick={() => setPage(page - 1)}
+            >
+              Previous
+            </button>
+            <span className="text-xs text-low">
+              {page + 1} / {pageCount || 1}
+            </span>
+            <button
+              disabled={page >= pageCount - 1}
+              className="text-xs disabled:opacity-50"
+              onClick={() => setPage(page + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
       {isLoading && (
         <div className="flex items-center justify-center border-x border-b border-grey-500 px-6 py-4 text-low">
           <Placeholder className="w-full" />

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+const useIsMobile = (breakpoint = 768) => {
+  const getWidth = () =>
+    typeof window === 'undefined' ? breakpoint + 1 : window.innerWidth;
+  const [isMobile, setIsMobile] = useState(getWidth() < breakpoint);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(getWidth() < breakpoint);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [breakpoint]);
+
+  return isMobile;
+};
+
+export default useIsMobile;

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { APP_VERSION, ARIO_DOCS_URL } from '@src/constants';
+import useIsMobile from '@src/hooks/useIsMobile';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -62,6 +63,7 @@ const Sidebar = () => {
     const storedValue = localStorage.getItem('sidebarOpen');
     return storedValue == null ? true : JSON.parse(storedValue);
   });
+  const isMobile = useIsMobile();
   const arioProcessId = useGlobalState((state) => state.arioProcessId);
 
   const [showChangLogModal, setShowChangeLogModal] = useState(false);
@@ -92,94 +94,118 @@ const Sidebar = () => {
   }, [sidebarOpen]);
 
   const sideBarClasses = `flex h-full w-fit flex-col p-6
-  dark:bg-grey-1000 dark:text-mid`;
+  dark:bg-grey-1000 dark:text-mid ${isMobile ? 'fixed top-0 left-0 z-40 w-64 max-w-[75%] shadow-one' : ''}`;
 
   return (
-    <aside className={sideBarClasses}>
-      <div className="flex h-9 pb-24">
-        <ArioLogoIcon className="h-[1.6875rem] w-[2.125rem]" />
-        {sidebarOpen && (
-          <div className="pl-3">
-            <p className="align-top text-sm leading-none text-neutrals-100">
-              NETWORK PORTAL
-            </p>
-            <p className="text-xs">by ar.io</p>
-          </div>
-        )}
-      </div>
-      <div className="dark:text-grey-100">
-        {ROUTES_PRIMARY.map(({ title, icon, path }, index) => (
-          <Button
-            key={index}
-            className="w-full"
-            icon={icon}
-            title={title}
-            text={sidebarOpen ? title : undefined}
-            active={location.pathname.startsWith(path)}
-            onClick={() => {
-              navigate(path);
-            }}
-          />
-        ))}
-      </div>
-      <div className="grow"></div>
-      <hr className="text-divider" />
-      <div className="py-3">
-        {ROUTES_SECONDARY.map(({ title, icon, path, action }, index) => (
-          <Button
-            key={index}
-            className="w-full"
-            icon={icon}
-            rightIcon={action ? <></> : <LinkArrowIcon className="size-3" />}
-            title={path || title}
-            text={sidebarOpen ? title : undefined}
-            onClick={
-              action ||
-              (() => {
-                window.open(path, '_blank');
-              })
-            }
-          />
-        ))}
-      </div>
-      <hr className="text-divider" />
-      <div className="pt-6">
-        <div
-          className={
-            sidebarOpen
-              ? 'flex items-center justify-end'
-              : 'flex items-center justify-center'
-          }
+    <>
+      {isMobile && !sidebarOpen && (
+        <button
+          className="fixed bottom-4 right-4 z-50 rounded-full bg-containerL3 p-3"
+          onClick={() => setSidebarOpen(true)}
         >
-          {sidebarOpen && (
+          <OpenDrawerIcon className="size-5" />
+        </button>
+      )}
+      {(!isMobile || sidebarOpen) && (
+        <aside className={sideBarClasses}>
+          {isMobile && (
             <button
-              className="grow pl-3 text-left text-xs text-low/50"
-              onClick={() => setShowChangeLogModal(true)}
+              className="absolute right-4 top-4"
+              onClick={() => setSidebarOpen(false)}
             >
-              v{APP_VERSION}-
-              {import.meta.env.VITE_GITHUB_HASH?.slice(0, 6)}
+              <CloseDrawerIcon className="size-5" />
             </button>
           )}
-          <button onClick={() => setSidebarOpen(!sidebarOpen)}>
-            {sidebarOpen ? (
-              <CloseDrawerIcon className="size-5" />
-            ) : (
-              <OpenDrawerIcon className="size-5" />
+          <div className="flex h-9 pb-24">
+            <ArioLogoIcon className="h-[1.6875rem] w-[2.125rem]" />
+            {sidebarOpen && (
+              <div className="pl-3">
+                <p className="align-top text-sm leading-none text-neutrals-100">
+                  NETWORK PORTAL
+                </p>
+                <p className="text-xs">by ar.io</p>
+              </div>
             )}
-          </button>
-        </div>
-      </div>
-      {showChangLogModal && (
-        <MarkdownModal
-          onClose={() => setShowChangeLogModal(false)}
-          title="Changelog"
-          markdownText={FORMATTED_CHANGELOG}
-        />
+          </div>
+          <div className="dark:text-grey-100">
+            {ROUTES_PRIMARY.map(({ title, icon, path }, index) => (
+              <Button
+                key={index}
+                className="w-full"
+                icon={icon}
+                title={title}
+                text={sidebarOpen ? title : undefined}
+                active={location.pathname.startsWith(path)}
+                onClick={() => {
+                  navigate(path);
+                }}
+              />
+            ))}
+          </div>
+          <div className="grow"></div>
+          <hr className="text-divider" />
+          <div className="py-3">
+            {ROUTES_SECONDARY.map(({ title, icon, path, action }, index) => (
+              <Button
+                key={index}
+                className="w-full"
+                icon={icon}
+                rightIcon={
+                  action ? <></> : <LinkArrowIcon className="size-3" />
+                }
+                title={path || title}
+                text={sidebarOpen ? title : undefined}
+                onClick={
+                  action ||
+                  (() => {
+                    window.open(path, '_blank');
+                  })
+                }
+              />
+            ))}
+          </div>
+          <hr className="text-divider" />
+          {!isMobile && (
+            <div className="pt-6">
+              <div
+                className={
+                  sidebarOpen
+                    ? 'flex items-center justify-end'
+                    : 'flex items-center justify-center'
+                }
+              >
+                {sidebarOpen && (
+                  <button
+                    className="grow pl-3 text-left text-xs text-low/50"
+                    onClick={() => setShowChangeLogModal(true)}
+                  >
+                    v{APP_VERSION}-
+                    {import.meta.env.VITE_GITHUB_HASH?.slice(0, 6)}
+                  </button>
+                )}
+                <button onClick={() => setSidebarOpen(!sidebarOpen)}>
+                  {sidebarOpen ? (
+                    <CloseDrawerIcon className="size-5" />
+                  ) : (
+                    <OpenDrawerIcon className="size-5" />
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+          {showChangLogModal && (
+            <MarkdownModal
+              onClose={() => setShowChangeLogModal(false)}
+              title="Changelog"
+              markdownText={FORMATTED_CHANGELOG}
+            />
+          )}
+          {showSettingsModal && (
+            <SettingsModal onClose={() => setShowSettingsModal(false)} />
+          )}
+        </aside>
       )}
-      {showSettingsModal && (
-        <SettingsModal onClose={() => setShowSettingsModal(false)} />
-      )}
-    </aside>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add hook `useIsMobile` to detect small screens
- update `TableView` to render cards with pagination on mobile
- collapse sidebar into a floating button on mobile

## Testing
- `yarn lint:check` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6861a9a5e5148328ac78c91695da8c33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table view now adapts to mobile devices by displaying data as paginated cards with easy navigation controls.
  * Sidebar layout and behavior are optimized for mobile, including a floating open button and an in-sidebar close button.
  * Introduced responsive detection for device type to enhance user experience across devices.

* **Enhancements**
  * Desktop table view and sidebar retain their existing features with improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->