### PR TITLE
Add mobile friendly view

### DIFF
--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -1,3 +1,4 @@
+import useIsMobile from '@src/hooks/useIsMobile';
 import {
   ColumnDef,
   ColumnSort,
@@ -6,6 +7,7 @@ import {
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
+  type HeaderContext,
 } from '@tanstack/react-table';
 import { useState } from 'react';
 import Placeholder from './Placeholder';
@@ -29,73 +31,80 @@ const TableView = <T, S>({
   shortTable?: boolean;
 }) => {
   const [sorting, setSorting] = useState<SortingState>([defaultSortingState]);
+  const isMobile = useIsMobile();
+  const [page, setPage] = useState(0);
 
   const table = useReactTable({
     columns,
     data,
     getCoreRowModel: getCoreRowModel<T>(),
-    getSortedRowModel: getSortedRowModel(), //provide a sorting row model
+    getSortedRowModel: getSortedRowModel(),
     state: { sorting },
     onSortingChange: setSorting,
   });
 
-  const maxHeightRemClass = shortTable 
-    ? `max-h-[16rem]`
-    : undefined;
+  const maxHeightRemClass = shortTable ? `max-h-[16rem]` : undefined;
+
+  const rows = table.getRowModel().rows;
+  const pageCount = Math.ceil(rows.length / 10);
+  const pagedRows = isMobile ? rows.slice(page * 10, page * 10 + 10) : rows;
 
   return (
     <>
-      <div className={`overflow-x-auto scrollbar ${maxHeightRemClass}`}>
-        <table className="w-full table-auto border-x border-b border-grey-500">
-          <thead className="sticky top-0 z-10 bg-containerL0 text-xs text-low">
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  const sortState = header.column.getIsSorted();
-                  return (
-                    <th key={header.id} className="py-2 pl-6">
-                      <button
-                        className="flex items-center gap-1 text-left"
-                        onClick={() => {
-                          setSorting([
-                            {
-                              id: header.column.id,
-                              desc: sortState
-                                ? sortState === 'desc'
-                                  ? false
-                                  : true
-                                : header.column.columnDef.sortDescFirst ?? true,
-                            },
-                          ]);
-                        }}
-                      >
-                        {flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                        {sortState ? (
-                          sortState === 'desc' ? (
-                            <SortDesc />
+      {!isMobile && (
+        <div className={`overflow-x-auto scrollbar ${maxHeightRemClass}`}>
+          <table className="w-full table-auto border-x border-b border-grey-500">
+            <thead className="sticky top-0 z-10 bg-containerL0 text-xs text-low">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    const sortState = header.column.getIsSorted();
+                    return (
+                      <th key={header.id} className="py-2 pl-6">
+                        <button
+                          className="flex items-center gap-1 text-left"
+                          onClick={() => {
+                            setSorting([
+                              {
+                                id: header.column.id,
+                                desc: sortState
+                                  ? sortState === 'desc'
+                                    ? false
+                                    : true
+                                  : header.column.columnDef.sortDescFirst ??
+                                    true,
+                              },
+                            ]);
+                          }}
+                        >
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                          {sortState ? (
+                            sortState === 'desc' ? (
+                              <SortDesc />
+                            ) : (
+                              <SortAsc />
+                            )
                           ) : (
-                            <SortAsc />
-                          )
-                        ) : (
-                          <div className="w-4" />
-                        )}
-                      </button>
-                    </th>
-                  );
-                })}
-              </tr>
-            ))}
-          </thead>
-          {!isLoading && (
-            <tbody className="overflow-y-auto text-sm">
-              {table.getRowModel().rows.map((row) => {
-                return (
+                            <div className="w-4" />
+                          )}
+                        </button>
+                      </th>
+                    );
+                  })}
+                </tr>
+              ))}
+            </thead>
+            {!isLoading && (
+              <tbody className="overflow-y-auto text-sm">
+                {pagedRows.map((row) => (
                   <tr
                     key={row.id}
-                    className={`border-t border-grey-500 text-low *:py-4 *:pl-6 ${onRowClick ? 'cursor-pointer' : ''}`}
+                    className={`border-t border-grey-500 text-low *:py-4 *:pl-6${
+                      onRowClick ? ' cursor-pointer' : ''
+                    }`}
                     onClick={
                       onRowClick ? () => onRowClick(row.original) : undefined
                     }
@@ -109,12 +118,69 @@ const TableView = <T, S>({
                       </td>
                     ))}
                   </tr>
-                );
-              })}
-            </tbody>
-          )}
-        </table>
-      </div>
+                ))}
+              </tbody>
+            )}
+          </table>
+        </div>
+      )}
+      {isMobile && !isLoading && (
+        <div className="space-y-4">
+          {pagedRows.map((row) => (
+            <div
+              key={row.id}
+              role={onRowClick ? 'button' : undefined}
+              tabIndex={onRowClick ? 0 : undefined}
+              className={`rounded-lg border border-grey-500 p-4 text-sm text-low${
+                onRowClick ? ' cursor-pointer' : ''
+              }`}
+              onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+              onKeyDown={
+                onRowClick
+                  ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        onRowClick(row.original);
+                      }
+                    }
+                  : undefined
+              }
+            >
+              {row.getAllCells().map((cell) => (
+                <div key={cell.id} className="mb-1 flex justify-between gap-2">
+                  <div className="text-xs text-low">
+                    {flexRender(
+                      cell.column.columnDef.header,
+                      cell.getContext() as unknown as HeaderContext<T, S>,
+                    )}
+                  </div>
+                  <div className="text-right">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+          <div className="flex justify-center gap-4 pt-2">
+            <button
+              disabled={page === 0}
+              className="text-xs disabled:opacity-50"
+              onClick={() => setPage(page - 1)}
+            >
+              Previous
+            </button>
+            <span className="text-xs text-low">
+              {page + 1} / {pageCount || 1}
+            </span>
+            <button
+              disabled={page >= pageCount - 1}
+              className="text-xs disabled:opacity-50"
+              onClick={() => setPage(page + 1)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
       {isLoading && (
         <div className="flex items-center justify-center border-x border-b border-grey-500 px-6 py-4 text-low">
           <Placeholder className="w-full" />

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+const useIsMobile = (breakpoint = 768) => {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' && window.innerWidth < breakpoint,
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(
+        typeof window !== 'undefined' && window.innerWidth < breakpoint,
+      );
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [breakpoint]);
+
+  return isMobile;
+};
+
+export default useIsMobile;

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { APP_VERSION, ARIO_DOCS_URL } from '@src/constants';
+import useIsMobile from '@src/hooks/useIsMobile';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -62,6 +63,7 @@ const Sidebar = () => {
     const storedValue = localStorage.getItem('sidebarOpen');
     return storedValue == null ? true : JSON.parse(storedValue);
   });
+  const isMobile = useIsMobile();
   const arioProcessId = useGlobalState((state) => state.arioProcessId);
 
   const [showChangLogModal, setShowChangeLogModal] = useState(false);
@@ -92,94 +94,132 @@ const Sidebar = () => {
   }, [sidebarOpen]);
 
   const sideBarClasses = `flex h-full w-fit flex-col p-6
-  dark:bg-grey-1000 dark:text-mid`;
+  dark:bg-grey-1000 dark:text-mid ${isMobile ? 'fixed top-0 left-0 z-40 w-64 max-w-[75%] shadow-one' : ''}`;
 
   return (
-    <aside className={sideBarClasses}>
-      <div className="flex h-9 pb-24">
-        <ArioLogoIcon className="h-[1.6875rem] w-[2.125rem]" />
-        {sidebarOpen && (
-          <div className="pl-3">
-            <p className="align-top text-sm leading-none text-neutrals-100">
-              NETWORK PORTAL
-            </p>
-            <p className="text-xs">by ar.io</p>
-          </div>
-        )}
-      </div>
-      <div className="dark:text-grey-100">
-        {ROUTES_PRIMARY.map(({ title, icon, path }, index) => (
-          <Button
-            key={index}
-            className="w-full"
-            icon={icon}
-            title={title}
-            text={sidebarOpen ? title : undefined}
-            active={location.pathname.startsWith(path)}
-            onClick={() => {
-              navigate(path);
-            }}
-          />
-        ))}
-      </div>
-      <div className="grow"></div>
-      <hr className="text-divider" />
-      <div className="py-3">
-        {ROUTES_SECONDARY.map(({ title, icon, path, action }, index) => (
-          <Button
-            key={index}
-            className="w-full"
-            icon={icon}
-            rightIcon={action ? <></> : <LinkArrowIcon className="size-3" />}
-            title={path || title}
-            text={sidebarOpen ? title : undefined}
-            onClick={
-              action ||
-              (() => {
-                window.open(path, '_blank');
-              })
-            }
-          />
-        ))}
-      </div>
-      <hr className="text-divider" />
-      <div className="pt-6">
-        <div
-          className={
-            sidebarOpen
-              ? 'flex items-center justify-end'
-              : 'flex items-center justify-center'
-          }
+    <>
+      {isMobile && !sidebarOpen && (
+        <button
+          className="fixed bottom-4 right-4 z-50 rounded-full bg-containerL3 p-3"
+          onClick={() => setSidebarOpen(true)}
         >
-          {sidebarOpen && (
-            <button
-              className="grow pl-3 text-left text-xs text-low/50"
-              onClick={() => setShowChangeLogModal(true)}
-            >
-              v{APP_VERSION}-
-              {import.meta.env.VITE_GITHUB_HASH?.slice(0, 6)}
-            </button>
+          <OpenDrawerIcon className="size-5" />
+        </button>
+      )}
+      {isMobile && sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30"
+          onClick={() => setSidebarOpen(false)}
+        ></div>
+      )}
+      {(!isMobile || sidebarOpen) && (
+        <aside className={sideBarClasses}>
+          {isMobile && (
+            <>
+              <button
+                className="absolute right-4 top-4"
+                onClick={() => setSidebarOpen(false)}
+              >
+                <CloseDrawerIcon className="size-5" />
+              </button>
+              <button
+                className="absolute bottom-4 right-4"
+                onClick={() => setSidebarOpen(false)}
+              >
+                <CloseDrawerIcon className="size-5" />
+              </button>
+            </>
           )}
-          <button onClick={() => setSidebarOpen(!sidebarOpen)}>
-            {sidebarOpen ? (
-              <CloseDrawerIcon className="size-5" />
-            ) : (
-              <OpenDrawerIcon className="size-5" />
+          <div className="flex h-9 pb-24">
+            <ArioLogoIcon className="h-[1.6875rem] w-[2.125rem]" />
+            {sidebarOpen && (
+              <div className="pl-3">
+                <p className="align-top text-sm leading-none text-neutrals-100">
+                  NETWORK PORTAL
+                </p>
+                <p className="text-xs">by ar.io</p>
+              </div>
             )}
-          </button>
-        </div>
-      </div>
-      {showChangLogModal && (
-        <MarkdownModal
-          onClose={() => setShowChangeLogModal(false)}
-          title="Changelog"
-          markdownText={FORMATTED_CHANGELOG}
-        />
+          </div>
+          <div className="dark:text-grey-100">
+            {ROUTES_PRIMARY.map(({ title, icon, path }, index) => (
+              <Button
+                key={index}
+                className="w-full"
+                icon={icon}
+                title={title}
+                text={sidebarOpen ? title : undefined}
+                active={location.pathname.startsWith(path)}
+                onClick={() => {
+                  navigate(path);
+                }}
+              />
+            ))}
+          </div>
+          <div className="grow"></div>
+          <hr className="text-divider" />
+          <div className="py-3">
+            {ROUTES_SECONDARY.map(({ title, icon, path, action }, index) => (
+              <Button
+                key={index}
+                className="w-full"
+                icon={icon}
+                rightIcon={
+                  action ? <></> : <LinkArrowIcon className="size-3" />
+                }
+                title={path || title}
+                text={sidebarOpen ? title : undefined}
+                onClick={
+                  action ||
+                  (() => {
+                    window.open(path, '_blank');
+                  })
+                }
+              />
+            ))}
+          </div>
+          <hr className="text-divider" />
+          {!isMobile && (
+            <div className="pt-6">
+              <div
+                className={
+                  sidebarOpen
+                    ? 'flex items-center justify-end'
+                    : 'flex items-center justify-center'
+                }
+              >
+                {sidebarOpen && (
+                  <button
+                    className="grow pl-3 text-left text-xs text-low/50"
+                    onClick={() => setShowChangeLogModal(true)}
+                  >
+                    v{APP_VERSION}-
+                    {import.meta.env.VITE_GITHUB_HASH?.slice(0, 6)}
+                  </button>
+                )}
+                <button onClick={() => setSidebarOpen(!sidebarOpen)}>
+                  {sidebarOpen ? (
+                    <CloseDrawerIcon className="size-5" />
+                  ) : (
+                    <OpenDrawerIcon className="size-5" />
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+          {showChangLogModal && (
+            <MarkdownModal
+              onClose={() => setShowChangeLogModal(false)}
+              title="Changelog"
+              markdownText={FORMATTED_CHANGELOG}
+            />
+          )}
+          {showSettingsModal && (
+            <SettingsModal onClose={() => setShowSettingsModal(false)} />
+          )}
+        </aside>
       )}
-      {showSettingsModal && (
-        <SettingsModal onClose={() => setShowSettingsModal(false)} />
-      )}
-    </aside>
+    </>
   );
 };
 

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -9,14 +9,14 @@ const Dashboard = () => {
   return (
     <div className="flex flex-col">
       <Header />
-      <div className="flex w-full gap-6 py-6">
-        <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-6 py-6 md:flex-row">
+        <div className="flex flex-col gap-6 md:w-1/3">
           <IOTokenDistributionPanel />
         </div>
 
-        <div className="flex min-w-[50rem] grow flex-col gap-6">
+        <div className="flex grow flex-col gap-6 md:min-w-[50rem]">
           <GatewaysInNetworkPanel />
-          <div className="grid h-fit grid-cols-2 gap-6">
+          <div className="grid h-fit grid-cols-1 gap-6 md:grid-cols-2">
             <ObserverPerformancePanel />
             <ArNSStatsPanel />
           </div>

--- a/src/pages/Gateway/index.tsx
+++ b/src/pages/Gateway/index.tsx
@@ -30,6 +30,7 @@ import useObserverBalances from '@src/hooks/useObserverBalances';
 import { useGlobalState } from '@src/store';
 import { showErrorToast } from '@src/utils/toast';
 import { useQueryClient } from '@tanstack/react-query';
+import { TriangleAlertIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import ActiveDelegates from './ActiveDelegates';
@@ -40,7 +41,6 @@ import PropertyDisplayPanel from './PropertyDisplayPanel';
 import SnitchRow from './SnitchRow';
 import SoftwareDetails from './SoftwareDetails';
 import StatsPanel from './StatsPanel';
-import { TriangleAlertIcon } from 'lucide-react';
 
 const Gateway = () => {
   const queryClient = useQueryClient();
@@ -81,7 +81,8 @@ const Gateway = () => {
 
   const hasLowBalance =
     observerBalances &&
-    (observerBalances.ar < 0.01 && observerBalances.turboCredits < 0.01);
+    observerBalances.ar < 0.01 &&
+    observerBalances.turboCredits < 0.01;
 
   const delegatedStakingEnabled = formState.allowDelegatedStaking == true;
 
@@ -345,10 +346,10 @@ const Gateway = () => {
             <div className="mt-1 text-sm">
               <ul>
                 <li>
-                  Observer AR and Turbo Credit balance is low. Please add more AR or Turbo Credits to the observer wallet.
+                  Observer AR and Turbo Credit balance is low. Please add more
+                  AR or Turbo Credits to the observer wallet.
                 </li>
               </ul>
-
             </div>
           </div>
         )}
@@ -363,8 +364,8 @@ const Gateway = () => {
       />
       <ActiveDelegates gateway={gateway} />
 
-      <div className="flex gap-6">
-        <div className="flex min-w-72 flex-col gap-6">
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="flex flex-col gap-6 md:min-w-72">
           <StatsPanel gateway={gateway} />
           {gateway?.weights && gateway?.status === 'joined' && (
             <div className="w-full rounded-xl border border-transparent-100-16 text-sm">
@@ -442,7 +443,7 @@ const Gateway = () => {
                 ))}
             </div>
             {editing ? (
-              <div className=" grid grid-cols-[14.375rem_auto] overflow-hidden border-t border-grey-500">
+              <div className="grid grid-cols-1 overflow-hidden border-t border-grey-500 md:grid-cols-[14.375rem_auto]">
                 {formRowDefs.map((rowDef, index) => {
                   return (
                     <FormRow


### PR DESCRIPTION
## Summary
- add hook `useIsMobile` to detect small screens
- update `TableView` to render cards with pagination on mobile with proper a11y
- collapse sidebar into a floating button on mobile
- improve sidebar to close when clicking outside and add bottom-right close button
- stack dashboard and gateway sections on small screens
- format gateway page

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn lint:check` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*
- `npx tsc --noEmit`
- `npx vitest run`
- `npx vite build` *(fails: FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6861a9a5e5148328ac78c91695da8c33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a mobile-friendly card layout for tables, including pagination controls and improved keyboard accessibility on mobile devices.
  * Added a floating button and overlay for opening and closing the sidebar on mobile devices.

* **Improvements**
  * Enhanced sidebar to function as a drawer on mobile, with responsive styling and dedicated close buttons.
  * Updated dashboard and gateway layouts for better responsiveness, ensuring panels and grids adapt to different screen sizes.

* **Bug Fixes**
  * Improved overall mobile usability and accessibility across key components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->