### PR TITLE
fix: use correct URL with observer address to obtain turbo credit balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2025-09-25
+
+### Fixed
+
+- Fix observer balance warning using incorrect value for Turbo credits
+
 ## [1.16.0] - 2025-09-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.16.1",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/hooks/useObserverBalances.ts
+++ b/src/hooks/useObserverBalances.ts
@@ -25,9 +25,12 @@ const useObserverBalances = (observerAddress?: string) => {
 
       // Get Turbo credits balance
       try {
-        const response = await fetch(`${TURBO_API_URL}/account/balance`, {
-          method: 'GET',
-        });
+        const response = await fetch(
+          `${TURBO_API_URL}/v1/account/balance?address=${observerAddress}`,
+          {
+            method: 'GET',
+          },
+        );
 
         if (!response.ok) {
           throw new Error(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Version
  - Bumped app version to 1.16.1.
- Bug Fixes
  - Corrected observer balance calculation to use the accurate Turbo Credits value, preventing incorrect warning messages.
  - Improved balance retrieval to reliably fetch account data, reducing false alerts for observers.
- Documentation
  - Updated changelog with a 1.16.1 entry detailing the balance warning fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->