### PR TITLE
feat: add Solana migration announcement banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.3] - 2026-04-27
+
+### Added
+
+- Site-wide Solana migration announcement banner with Learn More link
+- Banner auto-hides after May 15, 2026 snapshot date
+
+### Fixed
+
+- Mobile hamburger menu positioning now adapts to banner height dynamically
+- Content area overflow when multiple banners are displayed
+
 ## [1.24.2] - 2026-01-23
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,22 +25,36 @@ yarn tsc --noEmit  # Type check without building
 
 # Build and deploy
 yarn build         # Production build
-yarn deploy        # Deploy to Arweave (requires env vars)
+yarn deploy        # Deploy to Arweave (requires VITE_IO_PROCESS_ID, VITE_ARNS_NAME, DEPLOY_KEY env vars)
 ```
+
+## Code Conventions
+
+- **Formatting**: Biome with single quotes, 2-space indent
+- **Commits**: Conventional Commits enforced via commitlint (`feat:`, `fix:`, `chore:`, etc.)
+- **Pre-commit**: Husky runs lint-staged which auto-fixes with Biome on `*.{ts,tsx,js,md,json}`
+- **Path aliases**: Use `@src/*` for `./src/*` and `@tests/*` for `./tests/*` (configured in both tsconfig.json and vite.config.ts)
+- **SVGs**: Import as React components via vite-plugin-svgr; icon components live in `/src/components/icons/` (only barrel export in the project)
 
 ## High-Level Architecture
 
+### Provider Stack (App.tsx)
+
+Components wrap in this order (outermost first):
+`WagmiProvider` → `QueryClientProvider` → `GlobalDataProvider` → `WalletProvider` → `MathJaxContext` → `RouterProvider`
+
 ### State Management
 
-- **Zustand** for global state with two stores:
+- **Zustand** for global state:
   - `useGlobalState` (`/src/store/globalState.ts`) - wallet info, SDK instances, current epoch, block height, theme
   - `useSettings` (`/src/store/settings.ts`) - user-configurable settings (AO CU URL, ARIO process ID)
+  - `useColumnPreferences` (`/src/store/columnPreferences.ts`) - table column visibility
 - **React Query** for server state with 5-minute default cache time
 - **IndexedDB** (via Dexie) for persistent caching of observations and epochs (`/src/store/db.ts`)
 
 ### Data Fetching Pattern
 
-All data fetching uses custom hooks in `/src/hooks/` following this pattern:
+45+ custom hooks in `/src/hooks/` follow this pattern:
 
 ```typescript
 const useDataHook = (params) => {
@@ -69,6 +83,7 @@ const useDataHook = (params) => {
 - Wallet connectors in `/src/services/wallets/` implement `NetworkPortalWalletConnector` interface
 - `WalletProvider` component handles wallet connection lifecycle and events
 - Wallet type persisted in localStorage
+- Wagmi config handles Ethereum chain interactions (mainnet only)
 
 ### App Initialization
 
@@ -80,10 +95,9 @@ const useDataHook = (params) => {
 
 ### Routing
 
-- Hash-based routing with React Router v6
-- Lazy-loaded route components
-- Main routes: `/dashboard`, `/gateways`, `/gateways/:ownerId`, `/staking`, `/observers`, `/balances`, `/extensions`
-- Nested routes for reports: `/gateways/:ownerId/reports`, `/gateways/:ownerId/reports/:reportId`
+- Hash-based routing (`createHashRouter`) with React Router v6, wrapped by Sentry
+- All route components lazy-loaded with `React.lazy()` except Dashboard
+- Routes: `/dashboard`, `/gateways`, `/gateways/:ownerId`, `/gateways/:ownerId/reports`, `/gateways/:ownerId/reports/:reportId`, `/gateways/:ownerId/observe`, `/staking`, `/observers`, `/balances`, `/balances/:walletAddress`, `/extensions`
 
 ### Key Domain Concepts
 
@@ -95,13 +109,20 @@ const useDataHook = (params) => {
 
 ### Important Directories
 
-- `/src/components/` - Reusable UI components
+- `/src/components/` - Reusable UI components (flat structure with `/forms`, `/modals`, `/panels`, `/charts` subdirs)
 - `/src/hooks/` - Data fetching and business logic hooks
-- `/src/pages/` - Route page components (organized by feature)
-- `/src/services/` - External service integrations
+- `/src/pages/` - Route page components (one directory per page with `index.tsx`)
+- `/src/services/` - External service integrations (Sentry, wallet connectors)
 - `/src/store/` - Zustand state management
 - `/src/utils/` - Helper functions
-- `/tests/` - Test files (also some co-located in `/src/`)
+- `/tokens/` - Design token definitions (primitives.json consumed by Tailwind config)
+- `/tests/` - Test files (some also co-located in `/src/`)
+
+### Testing
+
+- Vitest with globals enabled (no need to import `describe`, `it`, `expect`, etc.)
+- Separate `vitest.config.ts` for test configuration
+- Coverage thresholds: 80% for branches, functions, and lines
 
 ### Development Notes
 
@@ -109,4 +130,4 @@ const useDataHook = (params) => {
 - Environment variables use `VITE_` prefix
 - Pre-commit hooks run Biome via Husky
 - CI/CD deploys to GitHub Pages (staging) and Arweave (production)
-- Uses Tailwind CSS with custom design tokens in `/tokens/`
+- Tailwind CSS with custom design tokens in `/tokens/`, Rubik font, dark mode support

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "1.24.2",
+  "version": "1.24.3",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,0 +1,21 @@
+function AnnouncementBanner() {
+  return (
+    <div className="flex flex-row items-center justify-center gap-2 bg-gradient-to-r from-gradient-primary-start to-gradient-primary-end px-4 py-2 text-sm text-grey-1100">
+      <span>
+        <span className="font-bold">Ar.io is migrating to Solana.</span>{' '}
+        Gateways will continue to serve names and data. Register before the May
+        15, 2026 snapshot!
+      </span>
+      <a
+        href="https://ar.io/solana-migration/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="whitespace-nowrap font-bold underline hover:opacity-80"
+      >
+        Learn More →
+      </a>
+    </div>
+  );
+}
+
+export default AnnouncementBanner;

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,14 +1,28 @@
 import { ExternalLink } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 const SNAPSHOT_DATE = new Date('2026-05-15T00:00:00Z');
 
 function AnnouncementBanner() {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const delay = SNAPSHOT_DATE.getTime() - Date.now();
+    if (delay <= 0) return;
+    const timer = setTimeout(() => setTick((t) => t + 1), delay);
+    return () => clearTimeout(timer);
+  }, []);
+
   if (Date.now() > SNAPSHOT_DATE.getTime()) {
     return null;
   }
 
   return (
-    <div className="flex flex-row flex-wrap items-center justify-center gap-x-2 bg-gradient-to-r from-gradient-primary-start to-gradient-primary-end px-4 py-2 text-center text-sm text-grey-1100 dark:text-grey-1100">
+    <div
+      role="banner"
+      aria-label="Migration announcement"
+      className="flex flex-row flex-wrap items-center justify-center gap-x-2 bg-gradient-to-r from-gradient-primary-start to-gradient-primary-end px-4 py-2 text-center text-sm text-grey-1100 dark:text-grey-1100"
+    >
       <span>
         <span className="font-bold">Ar.io is migrating to Solana.</span>{' '}
         Gateways will continue to serve names and data. Register before the May

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,3 +1,5 @@
+import { ExternalLink } from 'lucide-react';
+
 const SNAPSHOT_DATE = new Date('2026-05-15T00:00:00Z');
 
 function AnnouncementBanner() {
@@ -18,7 +20,7 @@ function AnnouncementBanner() {
         rel="noopener noreferrer"
         className="whitespace-nowrap font-bold underline hover:opacity-80"
       >
-        Learn More →
+        Learn More <ExternalLink className="inline size-3" />
       </a>
     </div>
   );

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,6 +1,12 @@
+const SNAPSHOT_DATE = new Date('2026-05-15T00:00:00Z');
+
 function AnnouncementBanner() {
+  if (Date.now() > SNAPSHOT_DATE.getTime()) {
+    return null;
+  }
+
   return (
-    <div className="flex flex-row items-center justify-center gap-2 bg-gradient-to-r from-gradient-primary-start to-gradient-primary-end px-4 py-2 text-sm text-grey-1100">
+    <div className="flex flex-row flex-wrap items-center justify-center gap-x-2 bg-gradient-to-r from-gradient-primary-start to-gradient-primary-end px-4 py-2 text-center text-sm text-grey-1100 dark:text-grey-1100">
       <span>
         <span className="font-bold">Ar.io is migrating to Solana.</span>{' '}
         Gateways will continue to serve names and data. Register before the May

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -25,8 +25,7 @@ function AnnouncementBanner() {
     >
       <span>
         <span className="font-bold">Ar.io is migrating to Solana.</span>{' '}
-        Gateways will continue to serve names and data. Register before the May
-        15, 2026 snapshot!
+        Register before the May 15, 2026 snapshot!
       </span>
       <a
         href="https://ar.io/solana-migration/"

--- a/src/layout/AppRouterLayout.tsx
+++ b/src/layout/AppRouterLayout.tsx
@@ -1,20 +1,15 @@
 import AnnouncementBanner from '@src/components/AnnouncementBanner';
 import NetworkStatusBanner from '@src/components/NetworkStatusBanner';
-import { useGlobalState } from '@src/store';
 import { Toaster } from 'react-hot-toast';
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
 
 function AppRouterLayout() {
-  const aoCongested = useGlobalState((state) => state.aoCongested);
-
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden dark:bg-grey-1000 dark:text-grey-100">
       <AnnouncementBanner />
       <NetworkStatusBanner />
-      <div
-        className={`flex h-full ${aoCongested ? 'h-[calc(100vh-2rem)]' : ''}`}
-      >
+      <div className="relative flex min-h-0 flex-1">
         <Sidebar />
         <main className="flex-1 overflow-hidden lg:pl-0">
           <Outlet />

--- a/src/layout/AppRouterLayout.tsx
+++ b/src/layout/AppRouterLayout.tsx
@@ -1,3 +1,4 @@
+import AnnouncementBanner from '@src/components/AnnouncementBanner';
 import NetworkStatusBanner from '@src/components/NetworkStatusBanner';
 import { useGlobalState } from '@src/store';
 import { Toaster } from 'react-hot-toast';
@@ -9,6 +10,7 @@ function AppRouterLayout() {
 
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden dark:bg-grey-1000 dark:text-grey-100">
+      <AnnouncementBanner />
       <NetworkStatusBanner />
       <div
         className={`flex h-full ${aoCongested ? 'h-[calc(100vh-2rem)]' : ''}`}

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -123,6 +123,7 @@ const Sidebar = () => {
     lg:translate-x-0`;
 
   // Mobile menu button (only visible on mobile)
+  // Positioned absolutely relative to AppRouterLayout's "relative flex" wrapper
   const mobileMenuButton = isMobile && !isMobileOpen && (
     <button
       onClick={toggleMobileMenu}

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -129,7 +129,7 @@ const Sidebar = () => {
     <button
       onClick={toggleMobileMenu}
       onKeyDown={(e) => e.key === 'Enter' && toggleMobileMenu()}
-      className={`fixed left-4 ${aoCongested ? 'top-[4.5rem]' : 'top-4'} z-50 rounded-md p-2 text-grey-100 focus:outline-none focus:ring-2 focus:ring-grey-100 lg:hidden`}
+      className={`fixed left-4 ${aoCongested ? 'top-[7rem]' : 'top-[3.5rem]'} z-50 rounded-md p-2 text-grey-100 focus:outline-none focus:ring-2 focus:ring-grey-100 lg:hidden`}
       aria-label={isMobileOpen ? 'Close menu' : 'Open menu'}
       aria-expanded={isMobileOpen}
       aria-controls="sidebar-navigation"

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -72,8 +72,6 @@ const Sidebar = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const sidebarOpen = useSettings((state) => state.sidebarOpen);
-  const aoCongested = useGlobalState((state) => state.aoCongested);
-
   const [showChangLogModal, setShowChangeLogModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
 
@@ -129,7 +127,7 @@ const Sidebar = () => {
     <button
       onClick={toggleMobileMenu}
       onKeyDown={(e) => e.key === 'Enter' && toggleMobileMenu()}
-      className={`fixed left-4 ${aoCongested ? 'top-[7rem]' : 'top-[3.5rem]'} z-50 rounded-md p-2 text-grey-100 focus:outline-none focus:ring-2 focus:ring-grey-100 lg:hidden`}
+      className="absolute left-4 top-4 z-50 rounded-md p-2 text-grey-100 focus:outline-none focus:ring-2 focus:ring-grey-100 lg:hidden"
       aria-label={isMobileOpen ? 'Close menu' : 'Open menu'}
       aria-expanded={isMobileOpen}
       aria-controls="sidebar-navigation"


### PR DESCRIPTION
## Summary
- Adds site-wide announcement banner: **Ar.io is migrating to Solana.** Gateways will continue to serve names and data. Register before the May 15, 2026 snapshot! Learn More →
- Banner auto-hides after the May 15, 2026 snapshot date
- Fixes mobile hamburger menu overlap by switching to relative positioning
- Replaces hardcoded content area height calc with flexbox for dynamic banner support
- Dark mode text color fix to prevent inheritance from parent container
- Bumps version to 1.24.3

## Test plan
- [ ] Verify banner displays on all pages (dashboard, gateways, staking, etc.)
- [ ] Verify "Learn More →" link opens https://ar.io/solana-migration/ in new tab
- [ ] Verify banner text is readable in dark mode (dark text on gradient)
- [ ] Verify mobile: hamburger menu is visible below the banner
- [ ] Verify mobile: banner text wraps gracefully on narrow screens
- [ ] Verify banner + network status banner stack correctly when AO is congested
- [ ] Verify banner auto-hides after May 15, 2026 (test by changing system date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site-wide Solana migration announcement banner with a Learn More link; banner auto-hides after May 15, 2026.

* **Bug Fixes**
  * Adjusted mobile hamburger/menu positioning to account for the announcement banner.
  * Reduced content overflow when multiple banners are shown.

* **Documentation**
  * Updated project docs and changelog for the 1.24.3 release (deployment, architecture, routing, testing, styling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->