### PR TITLE
fix: update snapshot date to June 1, 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.4] - 2026-05-06
+
+### Changed
+
+- Updated Solana migration snapshot date from May 15 to June 1, 2026
+
 ## [1.24.3] - 2026-04-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "1.24.3",
+  "version": "1.24.4",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-const SNAPSHOT_DATE = new Date('2026-05-15T00:00:00Z');
+const SNAPSHOT_DATE = new Date('2026-06-01T00:00:00Z');
 
 function AnnouncementBanner() {
   const [, setTick] = useState(0);
@@ -25,7 +25,7 @@ function AnnouncementBanner() {
     >
       <span>
         <span className="font-bold">Ar.io is migrating to Solana.</span>{' '}
-        Register before the May 15, 2026 snapshot!
+        Register before the June 1, 2026 snapshot!
       </span>
       <a
         href="https://ar.io/solana-migration/"


### PR DESCRIPTION
## Summary
- Updates Solana migration snapshot date from May 15 to June 1, 2026 in banner text and auto-hide timer
- Bumps version to 1.24.4

## Test plan
- [ ] Verify banner displays "Register before the June 1, 2026 snapshot!"
- [ ] Verify banner auto-hides after June 1, 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Solana migration snapshot deadline extended to June 1, 2026. Originally scheduled for May 15, this extension provides users with additional time to register and prepare for the migration. All in-app announcements and messaging have been updated to reflect the new deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->