### PR TITLE
Fix withdraw-all modal reopening

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -15,6 +15,7 @@ export const Button = ({
   title,
   text,
   active = false,
+  disabled = false,
   onClick,
 }: {
   forwardRef?: LegacyRef<HTMLButtonElement>;
@@ -25,6 +26,7 @@ export const Button = ({
   title: string;
   text?: ReactElement | string;
   active?: boolean;
+  disabled?: boolean;
   onClick?: MouseEventHandler;
 }) => {
   if (buttonType === ButtonType.PRIMARY) {
@@ -42,8 +44,11 @@ export const Button = ({
           title={title}
           ref={forwardRef}
           className={
-            btnClassNames + (icon ? ' justify-start' : ' justify-center')
+            btnClassNames +
+            (icon ? ' justify-start' : ' justify-center') +
+            (disabled ? ' cursor-not-allowed opacity-60' : '')
           }
+          disabled={disabled}
           onClick={onClick}
         >
           {icon}
@@ -71,6 +76,7 @@ export const Button = ({
         ref={forwardRef}
         title={title}
         className={buttonClassNames}
+        disabled={disabled}
         onClick={onClick}
       >
         {icon}

--- a/src/components/modals/WithdrawAllModal.tsx
+++ b/src/components/modals/WithdrawAllModal.tsx
@@ -3,12 +3,28 @@ import { WRITE_OPTIONS, log } from '@src/constants';
 import { useGlobalState } from '@src/store';
 import { showErrorToast } from '@src/utils/toast';
 import { useQueryClient } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Button, { ButtonType } from '../Button';
 import BaseModal from './BaseModal';
 import BlockingMessageModal from './BlockingMessageModal';
 import SuccessModal from './SuccessModal';
 import WithdrawWarning from './WithdrawWarning';
+
+// Space batched Solana withdrawals out so each transaction is built with
+// fresh vault PDA seeds instead of reusing the just-created withdrawal vault.
+const WITHDRAW_ALL_TRANSACTION_DELAY_MS = 1_200;
+
+const waitForNextWithdrawalTransaction = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, WITHDRAW_ALL_TRANSACTION_DELAY_MS);
+  });
+
+const getWithdrawableStakes = (
+  stakes: { owner: string; delegatedStake: number; gateway: Gateway }[],
+) =>
+  [...stakes]
+    .filter((stake) => stake.delegatedStake > 0)
+    .sort((a, b) => b.delegatedStake - a.delegatedStake);
 
 const WithdrawAllModal = ({
   onClose,
@@ -22,68 +38,98 @@ const WithdrawAllModal = ({
   const [showBlockingMessageModal, setShowBlockingMessageModal] =
     useState(false);
   const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [remainingStakes, setRemainingStakes] = useState(() =>
+    getWithdrawableStakes(activeStakes),
+  );
 
   const walletAddress = useGlobalState((state) => state.walletAddress);
   const arIOWriteableSDK = useGlobalState((state) => state.arIOWriteableSDK);
   const ticker = useGlobalState((state) => state.ticker);
 
-  const [initialActiveStakes] = useState(activeStakes);
-
-  const withDelegatedStake = useMemo(
-    () =>
-      [...initialActiveStakes]
-        .filter((stake) => stake.delegatedStake > 0)
-        .sort((a, b) => b.delegatedStake - a.delegatedStake),
-    [initialActiveStakes],
-  );
-
-  const totalWithdrawalMIO = withDelegatedStake.reduce(
+  const totalWithdrawalMIO = remainingStakes.reduce(
     (acc, stake) => acc + stake.delegatedStake,
     0,
   );
 
+  const refreshStakeQueries = () => {
+    if (!walletAddress) {
+      return;
+    }
+
+    void Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ['gateway', walletAddress.toString()],
+        refetchType: 'all',
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['gateways'],
+        refetchType: 'all',
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ['delegateStakes'],
+        refetchType: 'all',
+      }),
+    ]).catch((error) => {
+      log.error('Failed to refresh stakes after withdraw all', error);
+    });
+  };
+
+  useEffect(() => {
+    if (!showSuccessModal && !isProcessing && remainingStakes.length === 0) {
+      onClose();
+    }
+  }, [isProcessing, onClose, remainingStakes.length, showSuccessModal]);
+
   const processWithdrawAll = async () => {
-    if (withDelegatedStake.length === 0) {
+    if (isProcessing) {
+      return;
+    }
+
+    if (remainingStakes.length === 0) {
       onClose();
       return;
     }
 
     if (walletAddress && arIOWriteableSDK) {
+      let completedWithdrawal = false;
+      setIsProcessing(true);
       setShowBlockingMessageModal(true);
 
       try {
-        for (const stake of withDelegatedStake) {
-          if (stake.delegatedStake > 0) {
-            const { id: txID } = await arIOWriteableSDK.decreaseDelegateStake(
-              {
-                target: stake.owner,
-                decreaseQty: stake.delegatedStake, // read and write value both in mIO
-              },
-              WRITE_OPTIONS,
-            );
-
-            log.info(`Decrease Delegate Stake txID: ${txID}`);
+        for (const [index, stake] of remainingStakes.entries()) {
+          if (index > 0) {
+            await waitForNextWithdrawalTransaction();
           }
-        }
 
-        queryClient.invalidateQueries({
-          queryKey: ['gateway', walletAddress.toString()],
-          refetchType: 'all',
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['gateways'],
-          refetchType: 'all',
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['delegateStakes'],
-          refetchType: 'all',
-        });
+          const { id: txID } = await arIOWriteableSDK.decreaseDelegateStake(
+            {
+              target: stake.owner,
+              decreaseQty: stake.delegatedStake, // read and write value both in mIO
+            },
+            WRITE_OPTIONS,
+          );
+
+          completedWithdrawal = true;
+          setRemainingStakes((currentStakes) =>
+            currentStakes.filter(
+              (currentStake) => currentStake.owner !== stake.owner,
+            ),
+          );
+
+          log.info(`Decrease Delegate Stake txID: ${txID}`);
+        }
 
         setShowSuccessModal(true);
       } catch (e: any) {
         showErrorToast(`${e}`);
       } finally {
         setShowBlockingMessageModal(false);
+        setIsProcessing(false);
+
+        if (completedWithdrawal) {
+          refreshStakeQueries();
+        }
       }
     }
   };
@@ -102,8 +148,8 @@ const WithdrawAllModal = ({
 
             <div className="border-y border-grey-800 p-8">
               <table className="mb-8 w-full table-auto">
-                {withDelegatedStake.map((stake, index) => (
-                  <tr key={index} className="text-sm">
+                {remainingStakes.map((stake) => (
+                  <tr key={stake.owner} className="text-sm">
                     <td className="py-2 text-low ">
                       {stake.gateway.settings.label}
                     </td>
@@ -140,6 +186,7 @@ const WithdrawAllModal = ({
               <div className="mt-6 flex grow justify-center">
                 <Button
                   onClick={processWithdrawAll}
+                  disabled={isProcessing}
                   buttonType={ButtonType.PRIMARY}
                   title="Withdraw"
                   text={<div className="py-2">Withdraw</div>}

--- a/src/components/modals/WithdrawAllModal.tsx
+++ b/src/components/modals/WithdrawAllModal.tsx
@@ -3,7 +3,7 @@ import { WRITE_OPTIONS, log } from '@src/constants';
 import { useGlobalState } from '@src/store';
 import { showErrorToast } from '@src/utils/toast';
 import { useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Button, { ButtonType } from '../Button';
 import BaseModal from './BaseModal';
 import BlockingMessageModal from './BlockingMessageModal';
@@ -27,18 +27,27 @@ const WithdrawAllModal = ({
   const arIOWriteableSDK = useGlobalState((state) => state.arIOWriteableSDK);
   const ticker = useGlobalState((state) => state.ticker);
 
-  const sorted = activeStakes.sort(
-    (a, b) => b.delegatedStake - a.delegatedStake,
+  const [initialActiveStakes] = useState(activeStakes);
+
+  const withDelegatedStake = useMemo(
+    () =>
+      [...initialActiveStakes]
+        .filter((stake) => stake.delegatedStake > 0)
+        .sort((a, b) => b.delegatedStake - a.delegatedStake),
+    [initialActiveStakes],
   );
 
-  const withDelegatedStake = sorted.filter((stake) => stake.delegatedStake > 0);
-
-  const totalWithdrawalMIO = activeStakes.reduce(
+  const totalWithdrawalMIO = withDelegatedStake.reduce(
     (acc, stake) => acc + stake.delegatedStake,
     0,
   );
 
   const processWithdrawAll = async () => {
+    if (withDelegatedStake.length === 0) {
+      onClose();
+      return;
+    }
+
     if (walletAddress && arIOWriteableSDK) {
       setShowBlockingMessageModal(true);
 
@@ -81,63 +90,66 @@ const WithdrawAllModal = ({
 
   return (
     <>
-      <BaseModal onClose={onClose} useDefaultPadding={false}>
-        <div className="w-[calc(100vw-2rem)] text-left lg:w-[28.4375rem]">
-          <div className="px-8  pb-4 pt-6">
-            <div className="text-lg text-high">Withdraw All</div>
-            <div className="flex pt-2 text-xs text-low">
-              Withdraw all delegated stakes.
-            </div>
-          </div>
-
-          <div className="border-y border-grey-800 p-8">
-            <table className="mb-8 w-full table-auto">
-              {withDelegatedStake.map((stake, index) => (
-                <tr key={index} className="text-sm">
-                  <td className="py-2 text-low ">
-                    {stake.gateway.settings.label}
-                  </td>
-                  <td className="py-2">
-                    <a
-                      className="text-gradient"
-                      href={`https://${stake.gateway.settings.fqdn}`}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      {stake.gateway.settings.fqdn}
-                    </a>
-                  </td>
-                  <td className="py-2 text-right text-mid ">
-                    {new mARIOToken(stake.delegatedStake).toARIO().valueOf()}{' '}
-                    {ticker}
-                  </td>
-                </tr>
-              ))}
-            </table>
-
-            <WithdrawWarning />
-          </div>
-
-          <div className="bg-containerL0 px-8 pb-8 pt-6">
-            <div className="mt-1 flex text-sm text-mid">
-              <div className="grow">Total Withdrawal:</div>
-              <div>
-                {new mARIOToken(totalWithdrawalMIO).toARIO().valueOf()} {ticker}
+      {!showSuccessModal && (
+        <BaseModal onClose={onClose} useDefaultPadding={false}>
+          <div className="w-[calc(100vw-2rem)] text-left lg:w-[28.4375rem]">
+            <div className="px-8  pb-4 pt-6">
+              <div className="text-lg text-high">Withdraw All</div>
+              <div className="flex pt-2 text-xs text-low">
+                Withdraw all delegated stakes.
               </div>
             </div>
 
-            <div className="mt-6 flex grow justify-center">
-              <Button
-                onClick={processWithdrawAll}
-                buttonType={ButtonType.PRIMARY}
-                title="Withdraw"
-                text={<div className="py-2">Withdraw</div>}
-                className="w-full"
-              />
+            <div className="border-y border-grey-800 p-8">
+              <table className="mb-8 w-full table-auto">
+                {withDelegatedStake.map((stake, index) => (
+                  <tr key={index} className="text-sm">
+                    <td className="py-2 text-low ">
+                      {stake.gateway.settings.label}
+                    </td>
+                    <td className="py-2">
+                      <a
+                        className="text-gradient"
+                        href={`https://${stake.gateway.settings.fqdn}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {stake.gateway.settings.fqdn}
+                      </a>
+                    </td>
+                    <td className="py-2 text-right text-mid ">
+                      {new mARIOToken(stake.delegatedStake).toARIO().valueOf()}{' '}
+                      {ticker}
+                    </td>
+                  </tr>
+                ))}
+              </table>
+
+              <WithdrawWarning />
+            </div>
+
+            <div className="bg-containerL0 px-8 pb-8 pt-6">
+              <div className="mt-1 flex text-sm text-mid">
+                <div className="grow">Total Withdrawal:</div>
+                <div>
+                  {new mARIOToken(totalWithdrawalMIO).toARIO().valueOf()}{' '}
+                  {ticker}
+                </div>
+              </div>
+
+              <div className="mt-6 flex grow justify-center">
+                <Button
+                  onClick={processWithdrawAll}
+                  buttonType={ButtonType.PRIMARY}
+                  title="Withdraw"
+                  text={<div className="py-2">Withdraw</div>}
+                  className="w-full"
+                />
+              </div>
             </div>
           </div>
-        </div>
-      </BaseModal>
+        </BaseModal>
+      )}
       {showBlockingMessageModal && (
         <BlockingMessageModal
           onClose={() => setShowBlockingMessageModal(false)}

--- a/src/pages/Staking/MyStakesTable.tsx
+++ b/src/pages/Staking/MyStakesTable.tsx
@@ -401,9 +401,9 @@ const MyStakesTable = () => {
         }}
         tableId="my-stakes-unified"
       />
-      {showWithdrawAllModal && unifiedStakes !== undefined && (
+      {showWithdrawAllModal && (
         <WithdrawAllModal
-          activeStakes={unifiedStakes
+          activeStakes={(unifiedStakes ?? [])
             .filter((s) => s.status === 'Active')
             .map((s) => ({
               owner: s.owner,


### PR DESCRIPTION
### Motivation
- Prevent the Withdraw All confirmation modal from re-opening after the withdraw flow completes and showing `0 ARIO` due to background refetches updating the passed-in stakes.
- Ensure the modal behaves correctly when opened with no delegated stakes to withdraw.

### Description
- Snapshot the incoming `activeStakes` into component state (`initialActiveStakes`) so the list shown in the modal is stable while the modal is mounted (`src/components/modals/WithdrawAllModal.tsx`).
- Compute `withDelegatedStake` from the snapshot using `useMemo` and sort/filter it so background updates cannot mutate the in-modal data.
- Add a guard in `processWithdrawAll` that immediately closes the modal when `withDelegatedStake.length === 0` to avoid attempting a withdraw of `0 ARIO`.
- Hide the `BaseModal` while the success modal is shown by conditionally rendering the confirmation modal only when `!showSuccessModal` so the confirmation UI cannot reappear after success.

### Testing
- Ran `yarn lint:check` and code formatting; the lint check passed.
- Attempted `yarn test --runInBand` which failed because Vitest does not accept `--runInBand` (known option mismatch).
- Ran `yarn test` (Vitest) and all test files passed: 3 test files, 31 tests total passed.
- Built the app with `yarn build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21b1af58ec83288a90c2dd6a33b7bf)