### PR TITLE
Preserve Solana address settings per network

### DIFF
--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -10,10 +10,7 @@ import {
 import { create } from 'zustand';
 import { persist, subscribeWithSelector } from 'zustand/middleware';
 
-type Settings = {
-  solanaRpcUrl: string;
-  arweaveGqlUrl: string;
-  sidebarOpen: boolean;
+type SolanaAddressSettings = {
   solanaCoreProgramId: string;
   solanaGarProgramId: string;
   solanaArnsProgramId: string;
@@ -21,15 +18,89 @@ type Settings = {
   bridgeBalanceAddress: string;
 };
 
-const DEFAULT_SETTINGS: Settings = {
-  solanaRpcUrl: SOLANA_RPC_URL,
-  arweaveGqlUrl: DEFAULT_ARWEAVE_GQL_ENDPOINT,
-  sidebarOpen: true,
+type Settings = {
+  solanaRpcUrl: string;
+  arweaveGqlUrl: string;
+  sidebarOpen: boolean;
+  solanaAddressSettingsByNetwork: Record<
+    string,
+    Partial<SolanaAddressSettings>
+  >;
+} & SolanaAddressSettings;
+
+const SOLANA_ADDRESS_SETTING_KEYS: Array<keyof SolanaAddressSettings> = [
+  'solanaCoreProgramId',
+  'solanaGarProgramId',
+  'solanaArnsProgramId',
+  'solanaAntProgramId',
+  'bridgeBalanceAddress',
+];
+
+const getDefaultSolanaAddressSettings = (): SolanaAddressSettings => ({
   solanaCoreProgramId: SOLANA_CORE_PROGRAM_ID ?? '',
   solanaGarProgramId: SOLANA_GAR_PROGRAM_ID ?? '',
   solanaArnsProgramId: SOLANA_ARNS_PROGRAM_ID ?? '',
   solanaAntProgramId: SOLANA_ANT_PROGRAM_ID ?? '',
   bridgeBalanceAddress: BRIDGE_BALANCE_ADDRESS,
+});
+
+const getSolanaSettingsNetworkKey = (rpcUrl: string): string => {
+  const normalizedRpcUrl = rpcUrl.trim();
+  try {
+    const parsedUrl = new URL(normalizedRpcUrl);
+    return `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}`.toLowerCase();
+  } catch {
+    return normalizedRpcUrl.toLowerCase();
+  }
+};
+
+const getSolanaAddressSettingsForNetwork = (
+  state: Partial<Settings>,
+  networkKey: string,
+  includeTopLevelFallback = false,
+): SolanaAddressSettings => {
+  const defaults = getDefaultSolanaAddressSettings();
+  const networkSettings =
+    state.solanaAddressSettingsByNetwork?.[networkKey] ?? {};
+
+  return SOLANA_ADDRESS_SETTING_KEYS.reduce<SolanaAddressSettings>(
+    (settings, key) => ({
+      ...settings,
+      [key]:
+        networkSettings[key] ??
+        (includeTopLevelFallback && Object.hasOwn(state, key)
+          ? state[key]
+          : undefined) ??
+        defaults[key],
+    }),
+    defaults,
+  );
+};
+
+const getSolanaAddressSettingsPatch = (
+  settings: Partial<Settings>,
+): Partial<SolanaAddressSettings> => {
+  return SOLANA_ADDRESS_SETTING_KEYS.reduce<Partial<SolanaAddressSettings>>(
+    (patch, key) => {
+      if (Object.hasOwn(settings, key)) {
+        return {
+          ...patch,
+          [key]: settings[key],
+        };
+      }
+
+      return patch;
+    },
+    {},
+  );
+};
+
+const DEFAULT_SETTINGS: Settings = {
+  solanaRpcUrl: SOLANA_RPC_URL,
+  arweaveGqlUrl: DEFAULT_ARWEAVE_GQL_ENDPOINT,
+  sidebarOpen: true,
+  solanaAddressSettingsByNetwork: {},
+  ...getDefaultSolanaAddressSettings(),
 };
 
 const isLocalRpcUrl = (rpcUrl: string | undefined): boolean => {
@@ -50,18 +121,19 @@ export const useSettings = create<Settings>()(
     persist(() => DEFAULT_SETTINGS, {
       name: 'settings',
       merge: (persistedState, currentState) => {
+        const persistedSettings = (persistedState ?? {}) as Partial<Settings>;
         const mergedState = {
           ...currentState,
-          ...(persistedState as Partial<Settings>),
+          ...persistedSettings,
+          solanaAddressSettingsByNetwork: {
+            ...currentState.solanaAddressSettingsByNetwork,
+            ...persistedSettings.solanaAddressSettingsByNetwork,
+          },
         };
 
-        // Keep app startup pinned to staging defaults regardless of stale
-        // persisted values from previous environments.
+        // Keep app startup pinned to the current env-provided RPC unless the
+        // current env is localnet and a local RPC was persisted.
         mergedState.solanaRpcUrl = SOLANA_RPC_URL;
-        mergedState.solanaCoreProgramId = SOLANA_CORE_PROGRAM_ID ?? '';
-        mergedState.solanaGarProgramId = SOLANA_GAR_PROGRAM_ID ?? '';
-        mergedState.solanaArnsProgramId = SOLANA_ARNS_PROGRAM_ID ?? '';
-        mergedState.solanaAntProgramId = SOLANA_ANT_PROGRAM_ID ?? '';
 
         // If a stale localhost RPC was persisted from prior localnet sessions,
         // prefer the env-provided RPC (devnet/mainnet) on next boot.
@@ -72,10 +144,54 @@ export const useSettings = create<Settings>()(
           mergedState.solanaRpcUrl = SOLANA_RPC_URL;
         }
 
-        return mergedState;
+        const networkKey = getSolanaSettingsNetworkKey(
+          mergedState.solanaRpcUrl,
+        );
+        const solanaAddressSettings = getSolanaAddressSettingsForNetwork(
+          persistedSettings,
+          networkKey,
+          true,
+        );
+
+        return {
+          ...mergedState,
+          solanaAddressSettingsByNetwork: {
+            ...mergedState.solanaAddressSettingsByNetwork,
+            [networkKey]: solanaAddressSettings,
+          },
+          ...solanaAddressSettings,
+        };
       },
     }),
   ),
 );
 
-export const updateSettings = useSettings.setState;
+export const updateSettings = (settings: Partial<Settings>) => {
+  const solanaAddressSettingsPatch = getSolanaAddressSettingsPatch(settings);
+  const hasSolanaAddressSettingsPatch =
+    Object.keys(solanaAddressSettingsPatch).length > 0;
+
+  useSettings.setState((currentState) => {
+    const nextSolanaRpcUrl = settings.solanaRpcUrl ?? currentState.solanaRpcUrl;
+    const nextNetworkKey = getSolanaSettingsNetworkKey(nextSolanaRpcUrl);
+    const nextNetworkSolanaAddressSettings = hasSolanaAddressSettingsPatch
+      ? {
+          ...currentState.solanaAddressSettingsByNetwork[nextNetworkKey],
+          ...solanaAddressSettingsPatch,
+        }
+      : currentState.solanaAddressSettingsByNetwork[nextNetworkKey];
+
+    return {
+      ...(settings.solanaRpcUrl
+        ? getSolanaAddressSettingsForNetwork(currentState, nextNetworkKey)
+        : {}),
+      ...settings,
+      solanaAddressSettingsByNetwork: {
+        ...currentState.solanaAddressSettingsByNetwork,
+        ...(nextNetworkSolanaAddressSettings
+          ? { [nextNetworkKey]: nextNetworkSolanaAddressSettings }
+          : {}),
+      },
+    };
+  });
+};


### PR DESCRIPTION
### Motivation
- The Settings modal allows editing Solana program/token addresses but the persisted settings were being unconditionally overwritten by env defaults on app startup, which erased user overrides.  
- Address overrides need to be preserved per Solana network/RPC so users can maintain network-specific values and only get env defaults when no user value exists or when they explicitly reset.

### Description
- Added a `SolanaAddressSettings` type and a per-network map `solanaAddressSettingsByNetwork` to `src/store/settings.ts` and included per-network defaults in `DEFAULT_SETTINGS`.  
- Implemented `getSolanaSettingsNetworkKey` to normalize the Solana RPC URL into a stable network key and `getSolanaAddressSettingsForNetwork` to resolve the effective settings for a given network while falling back to env defaults only when no persisted value exists.  
- Updated the `persist` `merge` to migrate legacy top-level persisted Solana keys into the current network bucket and to hydrate the store using persisted per-network overrides instead of blindly applying env defaults.  
- Replaced the direct `useSettings.setState` export with an `updateSettings` wrapper that accepts the modal's existing top-level key shape and persists per-network patches into `solanaAddressSettingsByNetwork` so the modal continues to read/write the same keys via `updateSettings` while keeping per-network overrides consistent.

### Testing
- Ran `yarn test` and all test files passed (`3` test files, `31` tests total).  
- Ran `yarn lint:check` and `yarn lint:check src/store/settings.ts` and both reported no issues.  
- Ran type-check `yarn tsc --noEmit -p tsconfig.json` which surfaced unrelated SDK/wallet adapter type/module errors outside this change (these failures are pre-existing and not caused by this edit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21c9776f0c8328813dc6060ce3c2eb)