### PR TITLE
fix: include SDK config in epoch settings query key

### DIFF
--- a/src/hooks/useEpochSettings.ts
+++ b/src/hooks/useEpochSettings.ts
@@ -1,5 +1,6 @@
 import { EpochSettings } from '@ar.io/sdk/web';
 import { useGlobalState } from '@src/store';
+import { useSettings } from '@src/store/settings';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 
@@ -7,11 +8,20 @@ import dayjs from 'dayjs';
 const useEpochSettings = () => {
   const arIOReadSDK = useGlobalState((state) => state.arIOReadSDK);
   const solanaRpcUrl = useGlobalState((state) => state.solanaRpcUrl);
+  const solanaCoreProgramId = useSettings((state) => state.solanaCoreProgramId);
+  const solanaGarProgramId = useSettings((state) => state.solanaGarProgramId);
+  const solanaArnsProgramId = useSettings((state) => state.solanaArnsProgramId);
 
   const queryResults = useQuery<
     EpochSettings & { hasEpochZeroStarted: boolean }
   >({
-    queryKey: ['epochSettings', solanaRpcUrl],
+    queryKey: [
+      'epochSettings',
+      solanaRpcUrl,
+      solanaCoreProgramId,
+      solanaGarProgramId,
+      solanaArnsProgramId,
+    ],
     queryFn: async () => {
       if (!arIOReadSDK) {
         throw new Error('arIOReadSDK not available');


### PR DESCRIPTION
### Motivation
- `useEpochSettings` used a React Query `queryKey` containing only the `solanaRpcUrl` while its `queryFn` depends on the read SDK built from settings including program IDs, so `staleTime: Infinity` could lead to stale epoch settings when those program IDs change.
- `solanaAntProgramId` was not added because the current `makeArIOReadSDK` path uses `solanaCoreProgramId`, `solanaGarProgramId`, and `solanaArnsProgramId` only.

### Description
- Imported `useSettings` and read `solanaCoreProgramId`, `solanaGarProgramId`, and `solanaArnsProgramId` inside `src/hooks/useEpochSettings.ts`.
- Extended the React Query `queryKey` to `['epochSettings', solanaRpcUrl, solanaCoreProgramId, solanaGarProgramId, solanaArnsProgramId]` so the query will refetch when any SDK/config dependency changes.
- Kept `enabled: !!arIOReadSDK` and `staleTime: Infinity` unchanged to preserve intended caching semantics while ensuring invalidation on config changes.

### Testing
- Ran `yarn lint:check` and it passed.
- Ran `yarn test` and the test suite passed.
- Ran `yarn tsc --noEmit` which fails with existing project-wide typing/import errors unrelated to this hook change, so TypeScript failures were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21de7b7e648328854dd4f1661edfb0)