### PR TITLE
Fix gateway epoch query cache key

### DIFF
--- a/src/hooks/useGatewaysPerEpoch.ts
+++ b/src/hooks/useGatewaysPerEpoch.ts
@@ -11,12 +11,16 @@ const useGatewaysPerEpoch = () => {
   const arioReadSDK = useGlobalState((state) => state.arIOReadSDK);
   const solanaRpcUrl = useGlobalState((state) => state.solanaRpcUrl);
   const { data: epochs } = useEpochs();
+  const eligibleGatewayCounts = epochs?.map(
+    (epoch) => epoch?.distributions.totalEligibleGateways,
+  );
 
   const res = useQuery<Array<GatewayEpochCount>>({
     queryKey: [
       'gatewaysPerEpoch',
       epochs?.length,
       epochs?.[0]?.epochIndex,
+      eligibleGatewayCounts,
       solanaRpcUrl,
     ],
     queryFn: () => {


### PR DESCRIPTION
### Motivation
- The `useGatewaysPerEpoch` hook returned `totalEligibleGateways` per epoch but the React Query `queryKey` did not include per-epoch totals, which could allow stale counts to persist in the cache.
- Ensure any change to an epoch's `distributions.totalEligibleGateways` invalidates the cache and triggers a refetch.

### Description
- Add a derived `eligibleGatewayCounts` using `epochs?.map((epoch) => epoch?.distributions.totalEligibleGateways)` inside `useGatewaysPerEpoch`.
- Include `eligibleGatewayCounts` in the React Query `queryKey` array so changes to per-epoch totals update the cache key.
- Change is minimal and preserves the existing `queryFn` and `enabled` behavior.

### Testing
- Ran `yarn lint:check` and it passed.
- Ran `git diff --check` and it passed with no issues.
- Ran `yarn tsc --noEmit` which failed due to pre-existing unrelated type/dependency errors (missing Solana adapter modules and SDK export mismatches), and these errors are outside the scope of this hook change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21de903558832882bd398012c9b781)