### PR TITLE
Fix Solana RPC cache invalidation

### DIFF
--- a/src/store/globalState.ts
+++ b/src/store/globalState.ts
@@ -44,14 +44,16 @@ type GlobalStateActions = {
   setWriteSDK: (sdk?: SolanaARIOWriteable) => void;
 };
 
-/** Memoised kit RPC client with circuit breaker — rebuilt after `setSolanaConfig()`. */
+/** Memoised kit RPC client with circuit breaker, rebuilt when the RPC URL changes. */
 let _rpc: any | null = null;
+let _rpcUrl: string | null = null;
 export function getSolanaRpc(rpcUrl: string) {
-  if (!_rpc) {
+  if (!_rpc || _rpcUrl !== rpcUrl) {
     _rpc = createCircuitBreakerRpc({
       primaryUrl: rpcUrl,
       fallbackUrl: defaultFallbackUrl(rpcUrl),
     });
+    _rpcUrl = rpcUrl;
   }
   return _rpc;
 }


### PR DESCRIPTION
### Motivation
- Fix a bug where the memoized `_rpc` client could point to a stale network because its source URL was not tracked and it was never recreated when `rpcUrl` changed.

### Description
- Track the source URL with a new `let _rpcUrl: string | null = null` and change `getSolanaRpc` to recreate `_rpc` when the incoming `rpcUrl` differs, keeping `makeRpc(rpcUrl)` unchanged so callers still receive a client for the current URL (change in `src/store/globalState.ts`).

### Testing
- Ran `yarn lint:check` (passed), `yarn test` (3 test files, 31 tests passed), and `yarn build` (build completed successfully with warnings about bundle size/sourcemaps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21dec0ebd88328992b5dbf00044fca)