### PR TITLE
Fix zero-stake reward sentinels

### DIFF
--- a/src/utils/rewards.ts
+++ b/src/utils/rewards.ts
@@ -40,11 +40,14 @@ export const calculateOperatorRewards = (
   operatorStake: ARIOToken,
 ): OperatorRewards => {
   if (totalGateways <= 0) {
+    const EEY = operatorStake.valueOf() > 0 ? 0 : -1;
+    const EAY = EEY * EPOCHS_PER_YEAR;
+
     return {
       operatorStake,
       rewardsSharedPerEpoch: new ARIOToken(0),
-      EEY: 0,
-      EAY: 0,
+      EEY,
+      EAY,
     };
   }
   const epochRewards = protocolBalance.valueOf() * EPOCH_DISTRIBUTION_RATIO;
@@ -84,11 +87,17 @@ export const calculateGatewayRewards = (
   gateway: Gateway,
 ): GatewayRewards => {
   if (totalGateways <= 0) {
+    const totalDelegatedStake = new mARIOToken(
+      gateway.totalDelegatedStake,
+    ).toARIO();
+    const EEY = totalDelegatedStake.valueOf() > 0 ? 0 : -1;
+    const EAY = EEY * EPOCHS_PER_YEAR;
+
     return {
-      totalDelegatedStake: new mARIOToken(gateway.totalDelegatedStake).toARIO(),
+      totalDelegatedStake,
       rewardsSharedPerEpoch: new ARIOToken(0),
-      EEY: 0,
-      EAY: 0,
+      EEY,
+      EAY,
     };
   }
   const epochRewards = protocolBalance.valueOf() * EPOCH_DISTRIBUTION_RATIO;

--- a/tests/utils/rewards.test.ts
+++ b/tests/utils/rewards.test.ts
@@ -2,11 +2,32 @@ import { ARIOToken, Gateway } from '@ar.io/sdk/web';
 import {
   GatewayRewards,
   calculateGatewayRewards,
+  calculateOperatorRewards,
   calculateUserRewards,
 } from '@src/utils/rewards';
 
 describe('rewards.ts', () => {
   describe('calculateGatewayRewards', () => {
+    it('should return sentinel rewards when total gateways and delegated stake are zero', () => {
+      const gateway = {
+        totalDelegatedStake: 0,
+        settings: {
+          delegateRewardShareRatio: 50,
+        },
+      } as Gateway;
+
+      const result = calculateGatewayRewards(
+        new ARIOToken(50_000_000),
+        0,
+        gateway,
+      );
+
+      expect(result.totalDelegatedStake.valueOf()).toEqual(0);
+      expect(result.rewardsSharedPerEpoch.valueOf()).toEqual(0);
+      expect(result.EEY).toEqual(-1);
+      expect(result.EAY).toEqual(-365);
+    });
+
     it('should calculate gateway rewards correctly', () => {
       const protocolBalance = new ARIOToken(50_000_000);
       const totalGateways = 300;
@@ -29,6 +50,30 @@ describe('rewards.ts', () => {
       expect(result.rewardsSharedPerEpoch.valueOf()).toBeCloseTo(37.5, 1);
       expect(result.EEY).toBeCloseTo(0.004);
       expect(result.EAY).toBeCloseTo(0.27375);
+    });
+  });
+
+  describe('calculateOperatorRewards', () => {
+    it('should return sentinel rewards when total gateways and operator stake are zero', () => {
+      const gateway = {
+        totalDelegatedStake: 0,
+        settings: {
+          delegateRewardShareRatio: 50,
+        },
+      } as Gateway;
+      const operatorStake = new ARIOToken(0);
+
+      const result = calculateOperatorRewards(
+        new ARIOToken(50_000_000),
+        0,
+        gateway,
+        operatorStake,
+      );
+
+      expect(result.operatorStake).toBe(operatorStake);
+      expect(result.rewardsSharedPerEpoch.valueOf()).toEqual(0);
+      expect(result.EEY).toEqual(-1);
+      expect(result.EAY).toEqual(-365);
     });
   });
 


### PR DESCRIPTION
### Motivation
- Early-return branches in reward calculations set `EEY`/`EAY` to `0` when `totalGateways <= 0`, which broke the module's sentinel convention where `EEY = -1` signals zero-stake operators/delegations used by sorting and UI code.

### Description
- Update `calculateOperatorRewards` early-return to preserve the sentinel by computing `EEY = operatorStake.valueOf() > 0 ? 0 : -1` and `EAY = EEY * EPOCHS_PER_YEAR` and return those values instead of hard-coded zeros.
- Update `calculateGatewayRewards` early-return to materialize `totalDelegatedStake`, compute `EEY = totalDelegatedStake.valueOf() > 0 ? 0 : -1` and `EAY = EEY * EPOCHS_PER_YEAR`, and return those values.
- Add regression tests in `tests/utils/rewards.test.ts` covering the zero-gateway zero-delegated-stake and zero-gateway zero-operator-stake cases to assert sentinel `EEY === -1` and `EAY === -365`.

### Testing
- Ran `yarn lint:check tests/utils/rewards.test.ts src/utils/rewards.ts` which completed with no issues.
- Ran `yarn test` and all tests passed (`3` test files, `33` tests passed).
- An initial `vitest` invocation with the unsupported `--runInBand` flag failed, but rerunning tests without that flag succeeded as reported above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21ded050c08328bb1941cdfe1aa5bf)