### PR TITLE
fix: clear operator EAY when no gateways are joined

### DIFF
--- a/src/pages/Gateway/OperatorStake.tsx
+++ b/src/pages/Gateway/OperatorStake.tsx
@@ -51,7 +51,10 @@ const OperatorStake = ({ gateway, walletAddress }: OperatorStakeProps) => {
       const totalGateways = Object.values(gateways).filter(
         (g) => g.status === 'joined',
       ).length;
-      if (totalGateways === 0) return;
+      if (totalGateways === 0) {
+        setEAY(undefined);
+        return;
+      }
       const rewards = calculateOperatorRewards(
         new mARIOToken(protocolBalance).toARIO(),
         totalGateways,


### PR DESCRIPTION
### Motivation
- Prevent the UI from showing a stale operator EAY when there are no joined gateways by ensuring the EAY state is cleared when the joined gateway count is zero.

### Description
- In `src/pages/Gateway/OperatorStake.tsx` update the effect that computes rewards to call `setEAY(undefined)` and return when `totalGateways === 0`, leaving reward calculation unchanged for non-zero totals.

### Testing
- Ran `yarn lint:check` which passed, and `yarn test` (Vitest) which passed all tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21dedbc6588328a90ce6f46736c385)