### PR TITLE
Fix rewards claim disabled state for read-only wallets

### DIFF
--- a/src/pages/Dashboard/ClaimableRewardsSection.tsx
+++ b/src/pages/Dashboard/ClaimableRewardsSection.tsx
@@ -170,7 +170,8 @@ const ClaimableRewardsSection = () => {
 
   const hasWriteSupport = !!arIOWriteableSDK;
   const loading = withdrawalsLoading || vaultsLoading;
-  const claimRewardsDisabled = loading || isProcessingRewards;
+  const claimRewardsDisabled =
+    loading || isProcessingRewards || !hasWriteSupport;
 
   return (
     <div className="rounded-xl border border-grey-600 bg-containerL1 p-4 lg:p-5">


### PR DESCRIPTION
### Motivation
- Prevent the Claim All Rewards action from being active when the connected wallet is read-only by factoring write availability into the disabled state.

### Description
- Updated `claimRewardsDisabled` in `src/pages/Dashboard/ClaimableRewardsSection.tsx` to `loading || isProcessingRewards || !hasWriteSupport` so the button styling and helper text correctly reflect lack of write support (i.e. `arIOWriteableSDK`).

### Testing
- Ran `yarn biome check --unsafe src/pages/Dashboard/ClaimableRewardsSection.tsx`, which passed after formatting fixes.
- Ran `yarn tsc --noEmit -p tsconfig.build.json`, which failed due to pre-existing missing module / SDK type export errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21dee624e483288a035a9f78bc7004)