### PR TITLE
Preserve persisted Solana RPC/program IDs unless network tier changes

### DIFF
--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -131,27 +131,24 @@ export const useSettings = create<Settings>()(
           },
         };
 
-        // Keep app startup pinned to the current env-provided RPC unless the
-        // current env is localnet and a local RPC was persisted.
-        mergedState.solanaRpcUrl = SOLANA_RPC_URL;
+        const previousSolanaRpcUrl = mergedState.solanaRpcUrl;
+        const networkTierChanged =
+          isLocalRpcUrl(previousSolanaRpcUrl) !== isLocalRpcUrl(SOLANA_RPC_URL);
 
-        // If a stale localhost RPC was persisted from prior localnet sessions,
-        // prefer the env-provided RPC (devnet/mainnet) on next boot.
-        if (
-          isLocalRpcUrl(mergedState.solanaRpcUrl) &&
-          !isLocalRpcUrl(SOLANA_RPC_URL)
-        ) {
+        if (networkTierChanged) {
           mergedState.solanaRpcUrl = SOLANA_RPC_URL;
         }
 
         const networkKey = getSolanaSettingsNetworkKey(
           mergedState.solanaRpcUrl,
         );
-        const solanaAddressSettings = getSolanaAddressSettingsForNetwork(
-          persistedSettings,
-          networkKey,
-          true,
-        );
+        const solanaAddressSettings = networkTierChanged
+          ? getDefaultSolanaAddressSettings()
+          : getSolanaAddressSettingsForNetwork(
+              persistedSettings,
+              networkKey,
+              true,
+            );
 
         return {
           ...mergedState,


### PR DESCRIPTION
### Motivation
- The merge logic in `src/store/settings.ts` was unconditionally overwriting persisted Solana RPC and program IDs with env defaults, which made the localhost↔non-localnet migration check unreachable and discarded user-updated settings.
- The intent is to only reset to env defaults when the network tier (local vs non-local) actually changes, and otherwise preserve persisted per-network and top-level settings.

### Description
- In `src/store/settings.ts` capture the persisted RPC into `previousSolanaRpcUrl` and compute `networkTierChanged` with `isLocalRpcUrl(previousSolanaRpcUrl) !== isLocalRpcUrl(SOLANA_RPC_URL)` so the comparison uses the original persisted value.
- Only assign `mergedState.solanaRpcUrl = SOLANA_RPC_URL` when `networkTierChanged` is true, leaving persisted RPC when the tier is unchanged.
- Reset Solana program/address settings to `getDefaultSolanaAddressSettings()` when `networkTierChanged` is true, otherwise preserve per-network settings by calling `getSolanaAddressSettingsForNetwork(persistedSettings, networkKey, true)`.
- Changes are minimal and localized to the `merge` function in `src/store/settings.ts` and return the adjusted `solanaAddressSettings` into the merged state.

### Testing
- Ran `yarn lint:check` which passed with no issues.
- Ran `yarn test` and all unit tests passed (3 test files, 33 tests total).
- Ran `yarn build` which failed due to pre-existing dependency/type-resolution errors unrelated to this change (missing Solana modules and SDK export mismatches).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21e7bb316083288307e2dc3c4a07bd)