### PR TITLE
perf(hooks): collapse in-memory pagination loops into single fetches

### DIFF
--- a/src/hooks/useAllBalances.ts
+++ b/src/hooks/useAllBalances.ts
@@ -23,24 +23,15 @@ const useAllBalances = (options: UseAllBalancesOptions = {}) => {
         throw new Error('arIOReadSDK is not initialized');
       }
 
-      const allBalances: BalanceWithAddress[] = [];
-      let hasNextPage = true;
-      let cursor: string | undefined;
-      const limit = 1000;
+      // The SDK fetches the entire dataset and paginates in memory, so a
+      // single call requesting everything performs exactly one chain sweep.
+      const result = await arIOReadSDK.getBalances({
+        limit: Number.MAX_SAFE_INTEGER,
+        sortBy,
+        sortOrder,
+      });
 
-      // Fetch all balances paginated 1k at a time with sorting
-      while (hasNextPage) {
-        const result = await arIOReadSDK.getBalances({
-          cursor,
-          limit,
-          sortBy,
-          sortOrder,
-        });
-
-        allBalances.push(...result.items);
-        hasNextPage = result.hasMore;
-        cursor = result.nextCursor;
-      }
+      const allBalances: BalanceWithAddress[] = [...result.items];
 
       allBalances.sort((a, b) => {
         const valueA = sortBy === 'address' ? a.address : a.balance;

--- a/src/hooks/useAllDelegates.ts
+++ b/src/hooks/useAllDelegates.ts
@@ -13,24 +13,13 @@ const useAllDelegates = () => {
         throw new Error('arIOReadSDK is not initialized');
       }
 
-      const allDelegates: AllDelegates[] = [];
-      let hasNextPage = true;
-      let cursor: string | undefined;
-      const limit = 1000;
+      // The SDK paginates in memory, so a single call fetches the full set
+      // with exactly one chain sweep.
+      const result = await arIOReadSDK.getAllDelegates({
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
-      // Fetch all delegates paginated 1k at a time
-      while (hasNextPage) {
-        const result = await arIOReadSDK.getAllDelegates({
-          cursor,
-          limit,
-        });
-
-        allDelegates.push(...result.items);
-        hasNextPage = result.hasMore;
-        cursor = result.nextCursor;
-      }
-
-      return allDelegates;
+      return result.items;
     },
     staleTime: 5 * 60 * 1000,
     enabled: !!arIOReadSDK,

--- a/src/hooks/useAllGateways.ts
+++ b/src/hooks/useAllGateways.ts
@@ -49,24 +49,15 @@ const useAllGateways = (options: UseAllGatewaysOptions = {}) => {
         throw new Error('arIOReadSDK is not initialized');
       }
 
-      const allGateways: GatewayWithAddress[] = [];
-      let hasNextPage = true;
-      let cursor: string | undefined;
-      const limit = 1000;
+      // The SDK fetches the entire dataset and paginates in memory, so a
+      // single call requesting everything performs exactly one chain sweep.
+      const result = await arIOReadSDK.getGateways({
+        limit: Number.MAX_SAFE_INTEGER,
+        sortBy: sortBy as any,
+        sortOrder,
+      });
 
-      // Fetch all gateways paginated 1k at a time with sorting
-      while (hasNextPage) {
-        const result = await arIOReadSDK.getGateways({
-          cursor,
-          limit,
-          sortBy: sortBy as any,
-          sortOrder,
-        });
-
-        allGateways.push(...result.items);
-        hasNextPage = result.hasMore;
-        cursor = result.nextCursor;
-      }
+      const allGateways: GatewayWithAddress[] = [...result.items];
 
       allGateways.sort((a, b) => {
         const valueA =

--- a/src/hooks/useAllVaults.ts
+++ b/src/hooks/useAllVaults.ts
@@ -20,36 +20,28 @@ const useAllVaults = () => {
       }
 
       const vaultsByAddress = new Map<string, VaultsSummary>();
-      let hasNextPage = true;
-      let cursor: string | undefined;
-      const limit = 1000;
 
-      // Fetch all vaults paginated
-      while (hasNextPage) {
-        const result = await arIOReadSDK.getVaults({
-          cursor,
-          limit,
-        });
+      // The SDK paginates in memory, so a single call fetches the full set
+      // with exactly one chain sweep.
+      const result = await arIOReadSDK.getVaults({
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
-        // Process each vault
-        result.items.forEach((vault: WalletVault) => {
-          const existing = vaultsByAddress.get(vault.address) || {
-            address: vault.address,
-            vaultCount: 0,
-            totalVaultBalance: 0,
-          };
+      // Process each vault
+      result.items.forEach((vault: WalletVault) => {
+        const existing = vaultsByAddress.get(vault.address) || {
+          address: vault.address,
+          vaultCount: 0,
+          totalVaultBalance: 0,
+        };
 
-          existing.vaultCount += 1;
-          existing.totalVaultBalance += new mARIOToken(vault.balance)
-            .toARIO()
-            .valueOf();
+        existing.vaultCount += 1;
+        existing.totalVaultBalance += new mARIOToken(vault.balance)
+          .toARIO()
+          .valueOf();
 
-          vaultsByAddress.set(vault.address, existing);
-        });
-
-        hasNextPage = result.hasMore;
-        cursor = result.nextCursor;
-      }
+        vaultsByAddress.set(vault.address, existing);
+      });
 
       return vaultsByAddress;
     },

--- a/src/hooks/useDelegateStakes.ts
+++ b/src/hooks/useDelegateStakes.ts
@@ -23,24 +23,20 @@ const useDelegateStakes = (address?: string) => {
         withdrawals: [],
       };
 
-      let cursor: string | undefined;
+      // The SDK paginates in memory, so a single call fetches the full set
+      // with exactly one chain sweep.
+      const pageResult = await arIOReadSDK.getDelegations({
+        address,
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
-      do {
-        const pageResult = await arIOReadSDK.getDelegations({
-          address,
-          cursor,
-          limit: 100,
-        });
-
-        pageResult.items.forEach((d) => {
-          if (d.type === 'stake') {
-            retVal.stakes.push(d);
-          } else {
-            retVal.withdrawals.push(d);
-          }
-        });
-        cursor = pageResult.nextCursor;
-      } while (cursor !== undefined);
+      pageResult.items.forEach((d) => {
+        if (d.type === 'stake') {
+          retVal.stakes.push(d);
+        } else {
+          retVal.withdrawals.push(d);
+        }
+      });
 
       return retVal;
     },

--- a/src/hooks/useGatewayDelegates.ts
+++ b/src/hooks/useGatewayDelegates.ts
@@ -13,21 +13,14 @@ const useGatewayDelegateStakes = (address?: string) => {
         throw new Error('Address is not set');
       }
 
-      let cursor: string | undefined;
+      // The SDK paginates in memory, so a single call fetches the full set
+      // with exactly one chain sweep.
+      const pageResult = await arIOReadSDK.getGatewayDelegates({
+        address,
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
-      let results: Array<GatewayDelegateWithAddress> = [];
-
-      do {
-        const pageResult = await arIOReadSDK.getGatewayDelegates({
-          address,
-          cursor,
-          limit: 100,
-        });
-
-        results = results.concat(pageResult.items);
-
-        cursor = pageResult.nextCursor;
-      } while (cursor !== undefined);
+      const results: Array<GatewayDelegateWithAddress> = pageResult.items;
 
       return results.filter((delegate) => delegate.delegatedStake > 0);
     },

--- a/src/hooks/useGatewayVaults.ts
+++ b/src/hooks/useGatewayVaults.ts
@@ -13,23 +13,14 @@ const useGatewayVaults = (address?: string) => {
         throw new Error('Address is not set');
       }
 
-      let cursor: string | undefined;
+      // The SDK paginates in memory, so a single call fetches the full set
+      // with exactly one chain sweep.
+      const pageResult = await arIOReadSDK.getGatewayVaults({
+        address,
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
-      let results: Array<GatewayVault> = [];
-
-      do {
-        const pageResult = await arIOReadSDK.getGatewayVaults({
-          address,
-          cursor,
-          limit: 100,
-        });
-
-        results = results.concat(pageResult.items);
-
-        cursor = pageResult.nextCursor;
-      } while (cursor !== undefined);
-
-      return results;
+      return pageResult.items as Array<GatewayVault>;
     },
     staleTime: Infinity,
     enabled: !!address && !!arIOReadSDK,

--- a/src/hooks/useGateways.ts
+++ b/src/hooks/useGateways.ts
@@ -9,16 +9,16 @@ const useGateways = () => {
   const fetchAllGateways = async (
     arIOReadSDK: ARIORead,
   ): Promise<Record<string, Gateway>> => {
-    let cursor: string | undefined;
     const gateways: Record<string, Gateway> = {};
 
-    do {
-      const pageResult = await arIOReadSDK.getGateways({ cursor, limit: 1000 });
-      pageResult.items.forEach((gateway) => {
-        gateways[gateway.gatewayAddress] = gateway;
-      });
-      cursor = pageResult.nextCursor;
-    } while (cursor !== undefined);
+    // The SDK paginates in memory, so a single call fetches the full set
+    // with exactly one chain sweep.
+    const pageResult = await arIOReadSDK.getGateways({
+      limit: Number.MAX_SAFE_INTEGER,
+    });
+    pageResult.items.forEach((gateway) => {
+      gateways[gateway.gatewayAddress] = gateway;
+    });
 
     return gateways;
   };

--- a/src/hooks/usePaginatedGateways.ts
+++ b/src/hooks/usePaginatedGateways.ts
@@ -40,53 +40,35 @@ const usePaginatedGateways = (options: PageBasedOptions = {}) => {
     const safeLimit =
       Number.isFinite(limit) && limit > 0 && limit <= 1000 ? limit : 1000;
     const safePage = Number.isFinite(page) && page > 0 ? page : 1;
-    let currentCursor: string | undefined;
-    let currentPage = 1;
 
-    // If not on page 1, we need to skip to the correct page
-    while (currentPage < page) {
-      const pageResult = await arIOReadSDK.getGateways({
-        cursor: currentCursor,
-        limit: safeLimit,
-        sortBy: sortBy as any, // Type assertion needed for SDK
-        sortOrder,
-        filters,
-      });
-
-      if (pageResult.nextCursor) {
-        currentCursor = pageResult.nextCursor;
-        currentPage++;
-      } else {
-        // No more pages available
-        return {
-          items: [],
-          limit: safeLimit,
-          totalItems: pageResult.totalItems,
-          sortOrder: sortOrder as 'asc' | 'desc',
-          hasMore: false,
-          currentPage: safePage,
-          totalPages: Math.ceil(pageResult.totalItems / safeLimit),
-          hasNextPage: false,
-        };
-      }
-    }
-
-    // Fetch the target page
-    const pageResult = await arIOReadSDK.getGateways({
-      cursor: currentCursor,
-      limit: safeLimit,
+    // The SDK fetches the entire dataset and paginates in memory, so we fetch
+    // everything in a single chain sweep and slice the requested page locally.
+    const fullResult = await arIOReadSDK.getGateways({
+      limit: Number.MAX_SAFE_INTEGER,
       sortBy: sortBy as any, // Type assertion needed for SDK
       sortOrder,
       filters,
     });
 
-    const totalPages = Math.ceil(pageResult.totalItems / limit);
+    const totalItems = fullResult.totalItems ?? fullResult.items.length;
+    const totalPages = Math.ceil(totalItems / safeLimit);
+
+    const startIndex = (safePage - 1) * safeLimit;
+    const pageItems = fullResult.items.slice(
+      startIndex,
+      startIndex + safeLimit,
+    );
+    const hasNextPage = safePage < totalPages;
 
     return {
-      ...pageResult,
-      currentPage: page,
+      items: pageItems,
+      limit: safeLimit,
+      totalItems,
+      sortOrder: sortOrder as 'asc' | 'desc',
+      hasMore: hasNextPage,
+      currentPage: safePage,
       totalPages,
-      hasNextPage: !!pageResult.nextCursor,
+      hasNextPage,
     };
   };
 

--- a/src/hooks/usePrefetchBalances.ts
+++ b/src/hooks/usePrefetchBalances.ts
@@ -39,24 +39,15 @@ const usePrefetchBalances = (_options: UsePrefetchBalancesOptions = {}) => {
         await queryClient.prefetchQuery({
           queryKey,
           queryFn: async () => {
-            const allBalances: any[] = [];
-            let hasNextPage = true;
-            let cursor: string | undefined;
-            const limit = 1000;
+            // The SDK paginates in memory, so a single call fetches the full
+            // set with exactly one chain sweep.
+            const result = await arIOReadSDK.getBalances({
+              limit: Number.MAX_SAFE_INTEGER,
+              sortBy: targetSortBy,
+              sortOrder: targetSortOrder,
+            });
 
-            // Fetch all balances paginated with the target sort
-            while (hasNextPage) {
-              const result = await arIOReadSDK.getBalances({
-                cursor,
-                limit,
-                sortBy: targetSortBy,
-                sortOrder: targetSortOrder,
-              });
-
-              allBalances.push(...result.items);
-              hasNextPage = result.hasMore;
-              cursor = result.nextCursor;
-            }
+            const allBalances: any[] = [...result.items];
 
             // Convert mARIO to ARIO
             return allBalances.map((item) => ({

--- a/src/hooks/usePrefetchGateways.ts
+++ b/src/hooks/usePrefetchGateways.ts
@@ -47,58 +47,41 @@ const usePrefetchGateways = (options: UsePrefetchGatewaysOptions = {}) => {
         await queryClient.prefetchQuery({
           queryKey,
           queryFn: async () => {
-            // Use the same fetch logic as usePaginatedGateways
+            // Use the same fetch logic as usePaginatedGateways: the SDK
+            // paginates in memory, so fetch everything in one chain sweep and
+            // slice the requested page locally.
             const safeLimit =
               Number.isFinite(limit) && limit > 0 && limit <= 1000
                 ? limit
                 : 1000;
             const safePage = Number.isFinite(page) && page > 0 ? page : 1;
-            let currentCursor: string | undefined;
-            let currentPage = 1;
 
-            // Skip to the correct page
-            while (currentPage < page) {
-              const pageResult = await arIOReadSDK.getGateways({
-                cursor: currentCursor,
-                limit: safeLimit,
-                sortBy: sortBy as any,
-                sortOrder,
-                filters,
-              });
-
-              if (pageResult.nextCursor) {
-                currentCursor = pageResult.nextCursor;
-                currentPage++;
-              } else {
-                return {
-                  items: [],
-                  limit: safeLimit,
-                  totalItems: pageResult.totalItems,
-                  sortOrder: sortOrder as 'asc' | 'desc',
-                  hasMore: false,
-                  currentPage: safePage,
-                  totalPages: Math.ceil(pageResult.totalItems / safeLimit),
-                  hasNextPage: false,
-                };
-              }
-            }
-
-            // Fetch the target page
-            const pageResult = await arIOReadSDK.getGateways({
-              cursor: currentCursor,
-              limit: safeLimit,
+            const fullResult = await arIOReadSDK.getGateways({
+              limit: Number.MAX_SAFE_INTEGER,
               sortBy: sortBy as any,
               sortOrder,
               filters,
             });
 
-            const totalPages = Math.ceil(pageResult.totalItems / limit);
+            const totalItems = fullResult.totalItems ?? fullResult.items.length;
+            const totalPages = Math.ceil(totalItems / safeLimit);
+
+            const startIndex = (safePage - 1) * safeLimit;
+            const pageItems = fullResult.items.slice(
+              startIndex,
+              startIndex + safeLimit,
+            );
+            const hasNextPage = safePage < totalPages;
 
             return {
-              ...pageResult,
-              currentPage: page,
+              items: pageItems,
+              limit: safeLimit,
+              totalItems,
+              sortOrder: sortOrder as 'asc' | 'desc',
+              hasMore: hasNextPage,
+              currentPage: safePage,
               totalPages,
-              hasNextPage: !!pageResult.nextCursor,
+              hasNextPage,
             };
           },
           staleTime: 60 * 60 * 1000, // 1 hour

--- a/src/hooks/useVaults.ts
+++ b/src/hooks/useVaults.ts
@@ -11,16 +11,13 @@ const useVaults = () => {
     queryFn: async () => {
       if (!arioReadSDK) throw new Error('arIOReadSDK is not initialized');
 
-      let cursor: string | undefined;
-      let vaults: Array<WalletVault> = [];
+      // The SDK paginates in memory, so a single call fetches the full set
+      // with exactly one chain sweep.
+      const pageResult = await arioReadSDK.getVaults({
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
-      do {
-        const pageResult = await arioReadSDK.getVaults({ cursor, limit: 1000 });
-        vaults = vaults.concat(pageResult.items);
-        cursor = pageResult.nextCursor;
-      } while (cursor !== undefined);
-
-      return vaults;
+      return pageResult.items as Array<WalletVault>;
     },
     enabled: !!arioReadSDK,
     staleTime: Infinity,

--- a/src/hooks/useWithdrawals.ts
+++ b/src/hooks/useWithdrawals.ts
@@ -13,21 +13,14 @@ const useWithdrawals = (address?: string) => {
         throw new Error('Address is not set');
       }
 
-      const withdrawals: Array<UserWithdrawal> = [];
-      let cursor: string | undefined;
+      // The SDK paginates in memory, so a single call fetches the full set
+      // with exactly one chain sweep.
+      const pageResult = await arIOReadSDK.getWithdrawals({
+        address,
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
-      do {
-        const pageResult = await arIOReadSDK.getWithdrawals({
-          address,
-          cursor,
-          limit: 100,
-        });
-
-        withdrawals.push(...pageResult.items);
-        cursor = pageResult.nextCursor;
-      } while (cursor !== undefined);
-
-      return withdrawals;
+      return pageResult.items;
     },
     enabled: !!address && !!arIOReadSDK,
     staleTime: 5 * 60 * 1000,


### PR DESCRIPTION
## Summary

Removes redundant full-dataset re-fetches in the data-loading hooks.

The `@ar.io/sdk` Solana read methods (`getGateways`, `getBalances`, `getVaults`, `getAllDelegates`, `getDelegations`, `getGatewayDelegates`, `getGatewayVaults`, `getWithdrawals`) fetch the **entire** on-chain dataset and then paginate **in memory** by array index — the `cursor` is a numeric offset into an already-materialized list, not a chain cursor. So the `while (hasNextPage)` / `do…while (cursor)` loops in these hooks were triggering a **complete re-fetch of the whole dataset on every iteration** (N full chain sweeps to build one list), and it got worse as the network grew.

Each loop is replaced with a single call requesting the full set (`limit: Number.MAX_SAFE_INTEGER`), so there's exactly **one** chain sweep. `usePaginatedGateways` previously looped `getGateways()` up to *page* times to advance the in-memory cursor to the requested page (5 full sweeps to show page 5); it now fetches once and slices the page locally.

## Hooks changed (13)

`useAllGateways`, `useGateways`, `useAllBalances`, `useAllVaults`, `useVaults`, `useAllDelegates`, `useDelegateStakes`, `useGatewayDelegates`, `useGatewayVaults`, `useWithdrawals`, `usePrefetchBalances`, `usePrefetchGateways`, `usePaginatedGateways`.

## Behavior preserved

Query keys, `staleTime`, `enabled`, `placeholderData`, client-side sorting, filtering (`delegatedStake > 0`), mARIO→ARIO conversions, the per-vault Map aggregation, and the stake/withdrawal partition are all unchanged. The only behavioral change is the number of chain sweeps (N → 1).

## Compatibility

Fully compatible with the currently-pinned `@ar.io/sdk@4.0.0-solana.33` — uses no new SDK APIs. The companion SDK PR (ar-io/ar-io-sdk#659) adds internal speedups (parallelized gateway fetch, balance `dataSlice`, batched epoch reads) that these pages pick up automatically on the next `@ar.io/sdk` version bump.

## Verification

- `yarn tsc --noEmit` — clean
- `yarn test` — all real tests pass (the only failures are pre-existing macOS `._*` AppleDouble artifacts on the network volume, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data fetching across multiple queries to use more efficient single-call pagination instead of manual multi-page iteration, improving overall query performance and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->