### PR TITLE
chore: migrate from permaweb-deploy to @ar.io/deploy

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -36,12 +36,14 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build Next.js application
+      - name: Build application
         run: yarn build
 
-      - uses: permaweb/permaweb-deploy@v0.0.2
+      - name: Deploy PR preview
+        uses: ar-io/ar-io-deploy@v1
         with:
           deploy-key: ${{ secrets.DEPLOY_KEY }}
+          arns-key: ${{ secrets.ARNS_KEY }}
           arns-name: ${{ secrets.ARNS_NAME }}
           preview: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -69,12 +69,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
-      - name: Install, Build, and Deploy 🔧
+      - name: Install and Build 🔧
         run: |
           yarn install --frozen-lockfile
-          yarn deploy
+          yarn build
         env:
-          # FOR BUILD
           VITE_NODE_ENV: production
           VITE_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VITE_SENTRY_RELEASE: ${{ github.sha }}
@@ -85,6 +84,12 @@ jobs:
           VITE_SENTRY_DSN_PROJECT_ID: ${{ secrets.SENTRY_DSN_PROJECT_ID }}
           VITE_GITHUB_HASH: ${{ github.sha }}
           VITE_ARIO_PROCESS_ID: ${{ vars.VITE_ARIO_PROCESS_ID }}
-          VITE_ARNS_NAME: ${{ vars.ARNS_NAME }}
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
           VITE_AO_CU_URL: ${{ vars.VITE_AO_CU_URL }}
+
+      - name: Deploy to Arweave
+        uses: ar-io/ar-io-deploy@v1
+        with:
+          deploy-key: ${{ secrets.DEPLOY_KEY }}
+          arns-key: ${{ secrets.ARNS_KEY }}
+          arns-name: ${{ vars.ARNS_NAME }}
+          deploy-folder: ./dist

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "husky || true",
     "pre-commit": "lint-staged",
     "vis": "yarn vite-bundle-visualizer",
-    "deploy": "yarn build && permaweb-deploy --arns-name ${VITE_ARNS_NAME}"
+    "deploy": "yarn build && ario-deploy deploy --arns-name ${VITE_ARNS_NAME}"
   },
   "dependencies": {
     "@ar.io/sdk": "4.0.2-alpha.4",
@@ -82,7 +82,7 @@
     "lint-staged": "^15.2.2",
     "lodash": "^4.17.21",
     "nyc": "^15.1.0",
-    "permaweb-deploy": "^2.1.0",
+    "@ar.io/deploy": "^1.0.0",
     "postcss": "^8.4.35",
     "rimraf": "^5.0.5",
     "tailwind-scrollbar": "^3.1.0",


### PR DESCRIPTION
## Summary
- Replaces `permaweb/permaweb-deploy` GitHub Action with `ar-io/ar-io-deploy@v1` in production and PR preview workflows
- Replaces `permaweb-deploy` npm package with `@ar.io/deploy` in devDependencies and scripts
- Uses the two-key model: `DEPLOY_KEY` (Arweave) for uploads, `ARNS_KEY` (Solana) for ArNS updates

## Setup required
- Add `ARNS_KEY` secret (base58 Solana key with ArNS authority)

## Test plan
- [ ] Verify `ARNS_KEY` secret is set
- [ ] Test PR preview deployment
- [ ] Test production deployment on merge to main