### PR TITLE
fix: replace arweave.net with turbo-gateway.com and goldsky GQL

### DIFF
--- a/src/components/GlobalDataProvider.tsx
+++ b/src/components/GlobalDataProvider.tsx
@@ -10,6 +10,7 @@ import { fetchEncodedAccount } from '@solana/kit';
 import { log } from '@src/constants';
 import { useGlobalState } from '@src/store';
 import { cleanupDbCache } from '@src/store/db';
+import { probeArIOGateway } from '@src/utils/arweaveUrl';
 import { getErrorMessage } from '@src/utils/getErrorMessage';
 import { showErrorToast } from '@src/utils/toast';
 import { useQueryClient } from '@tanstack/react-query';
@@ -201,6 +202,13 @@ const GlobalDataProvider = ({ children }: { children: ReactElement }) => {
       cleanupDbCache(networkPortalDB, currentEpoch.epochIndex);
     }
   }, [currentEpoch, networkPortalDB]);
+
+  // Probe whether the app is served from an ar.io gateway (fire-and-forget).
+  // The cached result is used by arweaveTxUrl() to decide between relative
+  // URLs and turbo-gateway.com.
+  useEffect(() => {
+    probeArIOGateway();
+  }, []);
 
   // Handle window resize
   useEffect(() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,10 +39,11 @@ export const MAINNET_SOLANA_ANT_PROGRAM_ID = String(MAINNET_PROGRAM_IDS.ant);
 export const DEFAULT_ARWEAVE_PROTOCOL =
   import.meta.env.VITE_GATEWAY_PROTOCOL ?? 'https';
 export const DEFAULT_ARWEAVE_HOST =
-  import.meta.env.VITE_GATEWAY_HOST ?? 'arweave.net';
+  import.meta.env.VITE_GATEWAY_HOST ?? 'turbo-gateway.com';
 
 export const DEFAULT_ARWEAVE_GQL_ENDPOINT =
-  import.meta.env.VITE_ARWEAVE_GQL_ENDPOINT ?? 'https://arweave.net/graphql';
+  import.meta.env.VITE_ARWEAVE_GQL_ENDPOINT ??
+  'https://arweave-search.goldsky.com/graphql';
 export const DEFAULT_ARWEAVE_PORT =
   Number(import.meta.env.VITE_GATEWAY_PORT) ?? 443;
 

--- a/src/hooks/useLogo.ts
+++ b/src/hooks/useLogo.ts
@@ -2,6 +2,7 @@ import { ANT } from '@ar.io/sdk/web';
 import { address } from '@solana/kit';
 import { useGlobalState } from '@src/store';
 import { useSettings } from '@src/store';
+import { arweaveTxUrl } from '@src/utils/arweaveUrl';
 import { getOptionalSolanaAddress } from '@src/utils/solanaAddress';
 import { useQuery } from '@tanstack/react-query';
 
@@ -32,7 +33,7 @@ const useLogo = ({ primaryName }: { primaryName?: string }) => {
 
       const logoTxId = await antProcess.getLogo();
 
-      const imgSrc = `https://arweave.net/${logoTxId}`;
+      const imgSrc = arweaveTxUrl(logoTxId);
 
       return new Promise<HTMLImageElement>((resolve, reject) => {
         const img = new Image();

--- a/src/hooks/useReport.ts
+++ b/src/hooks/useReport.ts
@@ -1,10 +1,10 @@
-import { DEFAULT_ARWEAVE_HOST, DEFAULT_ARWEAVE_PROTOCOL } from '@src/constants';
+import { arweaveTxUrl } from '@src/utils/arweaveUrl';
 import { useQuery } from '@tanstack/react-query';
 import { gunzipSync, strFromU8 } from 'fflate';
 import ky from 'ky';
 
 export const downloadReport = async (reportId: string) => {
-  const reportURL = `${DEFAULT_ARWEAVE_PROTOCOL}://${DEFAULT_ARWEAVE_HOST}/${reportId}`;
+  const reportURL = arweaveTxUrl(reportId);
 
   const response = await ky.get(reportURL);
 

--- a/src/utils/arweaveUrl.ts
+++ b/src/utils/arweaveUrl.ts
@@ -1,0 +1,48 @@
+import { DEFAULT_ARWEAVE_HOST, DEFAULT_ARWEAVE_PROTOCOL } from '@src/constants';
+
+/**
+ * Cached result of the ar.io gateway check. Defaults to false (use
+ * turbo-gateway.com) until the async probe completes.
+ */
+let _isGateway: boolean | null = null;
+
+/**
+ * Probe whether the app is being served from an ar.io gateway by
+ * hitting /ar-io/info. Called once on app load; the result is cached
+ * for the session lifetime.
+ */
+export async function probeArIOGateway(): Promise<boolean> {
+  if (_isGateway !== null) return _isGateway;
+
+  try {
+    const res = await fetch('/ar-io/info', {
+      method: 'GET',
+      signal: AbortSignal.timeout(3000),
+    });
+    _isGateway = res.ok;
+  } catch {
+    _isGateway = false;
+  }
+  return _isGateway;
+}
+
+/**
+ * Returns the cached result of the gateway probe. If the probe hasn't
+ * completed yet, returns false (safe default — uses turbo-gateway.com).
+ */
+export function isOnArIOGateway(): boolean {
+  return _isGateway === true;
+}
+
+/**
+ * Build a URL for an Arweave transaction ID. Uses a relative path when
+ * the app is served from an ar.io gateway (so the serving gateway
+ * fetches the data), otherwise falls back to the configured gateway
+ * host (default: turbo-gateway.com).
+ */
+export function arweaveTxUrl(txId: string): string {
+  if (_isGateway) {
+    return `/${txId}`;
+  }
+  return `${DEFAULT_ARWEAVE_PROTOCOL}://${DEFAULT_ARWEAVE_HOST}/${txId}`;
+}

--- a/src/utils/arweaveUrl.ts
+++ b/src/utils/arweaveUrl.ts
@@ -17,9 +17,16 @@ export async function probeArIOGateway(): Promise<boolean> {
   try {
     const res = await fetch('/ar-io/info', {
       method: 'GET',
+      headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(3000),
     });
-    _isGateway = res.ok;
+    if (res.ok) {
+      const data = await res.json();
+      // Real ar.io gateways return JSON with a "wallet" field
+      _isGateway = typeof data?.wallet === 'string';
+    } else {
+      _isGateway = false;
+    }
   } catch {
     _isGateway = false;
   }

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,3 +1,5 @@
+import { arweaveTxUrl } from './arweaveUrl';
+
 /**
  * Converts an image reference (Arweave TX ID or HTTPS URL) to a full URL
  * @param imageRef - Either an Arweave transaction ID or a full HTTPS URL
@@ -10,21 +12,7 @@ export function getImageUrl(imageRef: string): string {
   }
 
   // Otherwise, treat it as an Arweave transaction ID
-  const hostname = window.location.hostname;
-
-  // Check if we're on a known ArNS gateway (but not localhost)
-  if (
-    (hostname.includes('.ar.io') ||
-      hostname.includes('.arweave.net') ||
-      hostname.includes('.permagate.io')) &&
-    !hostname.includes('localhost')
-  ) {
-    // Use relative URL for gateway access
-    return `/${imageRef}`;
-  }
-
-  // Fallback to arweave.net for centralized hosting
-  return `https://arweave.net/${imageRef}`;
+  return arweaveTxUrl(imageRef);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace all `arweave.net` references in the portal with reliable alternatives
- **Data fetching** (reports, logos, images): `turbo-gateway.com` as default, or relative URLs when the app is served from an ar.io gateway
- **GraphQL**: `arweave-search.goldsky.com/graphql`
- **Gateway detection**: probes `/ar-io/info` on app load to detect if served from an ar.io gateway (works for any gateway domain, not just known hostnames)

## Changes
- `src/constants.ts` — default host `arweave.net` → `turbo-gateway.com`, GQL endpoint → `goldsky.com`
- `src/utils/arweaveUrl.ts` — new shared utility: `arweaveTxUrl(txId)` builds URLs with gateway-aware routing, `probeArIOGateway()` one-time `/ar-io/info` check
- `src/utils/imageUtils.ts` — use `arweaveTxUrl` instead of hardcoded `arweave.net` fallback
- `src/hooks/useReport.ts` — use `arweaveTxUrl` for report downloads
- `src/hooks/useLogo.ts` — use `arweaveTxUrl` for logo images
- `src/components/GlobalDataProvider.tsx` — fire gateway probe on mount

## Test plan
- [ ] Reports load via turbo-gateway.com on localhost
- [ ] Logos render correctly
- [ ] Extension images resolve
- [ ] GraphQL queries (report metadata) work via goldsky
- [ ] On ar.io gateway deployment: relative URLs used instead of turbo-gateway.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)