### PR TITLE
feat(vaults): per-vault Release action + modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "deploy": "yarn build && ario-deploy deploy --arns-name ${VITE_ARNS_NAME}"
   },
   "dependencies": {
-    "@ar.io/sdk": "4.0.2-alpha.9",
+    "@ar.io/sdk": "4.1.0-alpha.2",
     "@fontsource/rubik": "^5.0.19",
     "@headlessui/react": "^2.2.0",
     "@radix-ui/react-dropdown-menu": "^2.1.2",

--- a/src/components/modals/ReleaseVaultModal.tsx
+++ b/src/components/modals/ReleaseVaultModal.tsx
@@ -1,0 +1,161 @@
+import { WRITE_OPTIONS } from '@src/constants';
+import { useGlobalState } from '@src/store';
+import {
+  formatDate,
+  formatWithCommas,
+  getTransactionExplorerUrl,
+} from '@src/utils';
+import { showErrorToast } from '@src/utils/toast';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import Button, { ButtonType } from '../Button';
+import LabelValueRow from '../LabelValueRow';
+import { LinkArrowIcon } from '../icons';
+import BaseModal from './BaseModal';
+import BlockingMessageModal from './BlockingMessageModal';
+import SuccessModal from './SuccessModal';
+
+/**
+ * Release an unlocked (expired) vault back to its owner.
+ *
+ * On Solana a vault does not auto-credit at expiry — the owner must call
+ * `release_vault`, which transfers the balance to their wallet and closes
+ * the vault (BD-050). This is non-destructive (you receive your own
+ * tokens), so unlike RevokeVaultModal there is no "type CONFIRM" gate.
+ */
+const ReleaseVaultModal = ({
+  vaultId,
+  balance,
+  endTimestamp,
+  onClose,
+}: {
+  vaultId: string;
+  balance: number;
+  endTimestamp: number;
+  onClose: () => void;
+}) => {
+  const queryClient = useQueryClient();
+
+  const walletAddress = useGlobalState((state) => state.walletAddress);
+  const arIOWriteableSDK = useGlobalState((state) => state.arIOWriteableSDK);
+  const ticker = useGlobalState((state) => state.ticker);
+
+  const [showBlockingMessageModal, setShowBlockingMessageModal] =
+    useState(false);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [txid, setTxid] = useState<string>();
+
+  const processReleaseVault = async () => {
+    if (walletAddress && arIOWriteableSDK) {
+      setShowBlockingMessageModal(true);
+
+      try {
+        const { id: txID } = await arIOWriteableSDK.releaseVault(
+          { vaultId: vaultId },
+          WRITE_OPTIONS,
+        );
+        setTxid(txID);
+
+        queryClient.invalidateQueries({
+          queryKey: ['vaults'],
+          refetchType: 'all',
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['balances'],
+          refetchType: 'all',
+        });
+
+        setShowSuccessModal(true);
+      } catch (e: any) {
+        showErrorToast(`${e}`);
+      } finally {
+        setShowBlockingMessageModal(false);
+      }
+    }
+  };
+
+  return (
+    <>
+      <BaseModal onClose={onClose} useDefaultPadding={false}>
+        <div className="w-[calc(100vw-2rem)] text-left lg:w-[28.4375rem]">
+          <div className="px-8  pb-4 pt-6">
+            <div className="text-lg text-high">Release Vault</div>
+          </div>
+
+          <div className="border-y border-grey-800 p-8 text-sm text-mid">
+            <div>
+              This vault has unlocked. Releasing it transfers the balance to
+              your wallet and closes the vault.
+            </div>
+          </div>
+
+          <div className="flex flex-col p-8">
+            <div className="flex flex-col gap-2">
+              <LabelValueRow
+                label="Balance:"
+                value={`${formatWithCommas(balance)} ${ticker}`}
+              />
+
+              <LabelValueRow
+                label="Unlocked On:"
+                value={formatDate(new Date(endTimestamp))}
+              />
+            </div>
+          </div>
+
+          <div className="bg-containerL0 px-8 pb-8 pt-6">
+            <div className="flex grow justify-center">
+              <Button
+                onClick={processReleaseVault}
+                buttonType={ButtonType.PRIMARY}
+                title="Release Vault"
+                text={<div className="py-2">Release Vault</div>}
+                className="w-full"
+              />
+            </div>
+          </div>
+        </div>
+      </BaseModal>
+      {showBlockingMessageModal && (
+        <BlockingMessageModal
+          onClose={() => setShowBlockingMessageModal(false)}
+          message="Sign the following data with your wallet to proceed."
+        ></BlockingMessageModal>
+      )}
+      {showSuccessModal && (
+        <SuccessModal
+          onClose={() => {
+            setShowSuccessModal(false);
+            onClose();
+          }}
+          title="Confirmed"
+          // FIXME: This uses a button as using a standard <a> tag does not work. Needs further investigation.
+          bodyText={
+            <div className="mb-8 text-sm text-mid">
+              <div>You have successfully released the vault.</div>
+              <div className="my-2 flex flex-col justify-center gap-2">
+                <div>Transaction ID:</div>
+                <button
+                  className="flex items-center justify-center break-all"
+                  title="View transaction on Solana Explorer"
+                  onClick={async () => {
+                    window.open(
+                      getTransactionExplorerUrl(txid!),
+                      '_blank',
+                      'noopener,noreferrer',
+                    );
+                  }}
+                >
+                  {txid}
+                  <LinkArrowIcon className="ml-1 size-3" />
+                </button>
+              </div>
+            </div>
+          }
+        />
+      )}
+    </>
+  );
+};
+
+export default ReleaseVaultModal;

--- a/src/pages/Balances/VaultsTable.tsx
+++ b/src/pages/Balances/VaultsTable.tsx
@@ -4,6 +4,7 @@ import Button, { ButtonType } from '@src/components/Button';
 import ColumnSelector from '@src/components/ColumnSelector';
 import TableView from '@src/components/TableView';
 import Tooltip from '@src/components/Tooltip';
+import ReleaseVaultModal from '@src/components/modals/ReleaseVaultModal';
 import RevokeVaultModal from '@src/components/modals/RevokeVaultModal';
 import useVaults from '@src/hooks/useVaults';
 import { useGlobalState } from '@src/store';
@@ -43,10 +44,32 @@ const VaultsTable = ({ walletAddress }: { walletAddress?: AoAddress }) => {
     | undefined
   >();
 
+  const [showReleaseVaultModal, setShowReleaseVaultModal] = useState<
+    | {
+        vaultId: string;
+        balance: number;
+        endTimestamp: number;
+      }
+    | undefined
+  >();
+
   const userCanRevoke = useMemo(() => {
     return vaults
       ? vaults.some(
           (vault) => vault.controller === userWalletAddress?.toString(),
+        )
+      : false;
+  }, [userWalletAddress, vaults]);
+
+  // Release is owner-signed and only valid after expiry. Show the action when
+  // the connected wallet owns an unlocked vault (Solana has no auto-credit at
+  // expiry — the owner must call release_vault; see SDK BD-050).
+  const userCanRelease = useMemo(() => {
+    return vaults
+      ? vaults.some(
+          (vault) =>
+            vault.address === userWalletAddress?.toString() &&
+            vault.endTimestamp <= Date.now(),
         )
       : false;
   }, [userWalletAddress, vaults]);
@@ -136,40 +159,74 @@ const VaultsTable = ({ walletAddress }: { walletAddress?: AoAddress }) => {
       }),
     ];
 
-    return userCanRevoke
+    return userCanRevoke || userCanRelease
       ? [
           ...base,
           columnHelper.display({
-            id: 'revoke',
+            id: 'actions',
             header: '',
             size: 0,
-            cell: ({ row }) =>
-              row.original.controller === userWalletAddress?.toString() ? (
-                <div className="flex justify-end pr-4">
-                  <Button
-                    buttonType={ButtonType.PRIMARY}
-                    active={true}
-                    title="Revoke Vault"
-                    text="Revoke"
-                    className="w-fit"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (walletAddress) {
-                        setShowRevokeVaultModal({
-                          recipient: walletAddress.toString(),
+            cell: ({ row }) => {
+              const isController =
+                row.original.controller === userWalletAddress?.toString();
+              const isOwner =
+                row.original.vaultAddress === userWalletAddress?.toString();
+              const isUnlocked = row.original.endTimestamp <= Date.now();
+              // Revoke: controller-only, valid only BEFORE expiry.
+              const canRevoke = isController && !isUnlocked;
+              // Release: owner-only, valid only AFTER expiry.
+              const canRelease = isOwner && isUnlocked;
+
+              if (!canRevoke && !canRelease) {
+                return null;
+              }
+
+              return (
+                <div className="flex justify-end gap-2 pr-4">
+                  {canRelease && (
+                    <Button
+                      buttonType={ButtonType.PRIMARY}
+                      active={true}
+                      title="Release Vault"
+                      text="Release"
+                      className="w-fit"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowReleaseVaultModal({
                           vaultId: row.original.vaultId,
                           balance: row.original.balance,
                           endTimestamp: row.original.endTimestamp,
                         });
-                      }
-                    }}
-                  />
+                      }}
+                    />
+                  )}
+                  {canRevoke && (
+                    <Button
+                      buttonType={ButtonType.PRIMARY}
+                      active={true}
+                      title="Revoke Vault"
+                      text="Revoke"
+                      className="w-fit"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (walletAddress) {
+                          setShowRevokeVaultModal({
+                            recipient: walletAddress.toString(),
+                            vaultId: row.original.vaultId,
+                            balance: row.original.balance,
+                            endTimestamp: row.original.endTimestamp,
+                          });
+                        }
+                      }}
+                    />
+                  )}
                 </div>
-              ) : null,
+              );
+            },
           }),
         ]
       : base;
-  }, [ticker, userCanRevoke, walletAddress, userWalletAddress]);
+  }, [ticker, userCanRevoke, userCanRelease, walletAddress, userWalletAddress]);
 
   return (
     <div>
@@ -195,6 +252,14 @@ const VaultsTable = ({ walletAddress }: { walletAddress?: AoAddress }) => {
           balance={showRevokeVaultModal.balance}
           endTimestamp={showRevokeVaultModal.endTimestamp}
           onClose={() => setShowRevokeVaultModal(undefined)}
+        />
+      )}
+      {showReleaseVaultModal && (
+        <ReleaseVaultModal
+          vaultId={showReleaseVaultModal.vaultId}
+          balance={showReleaseVaultModal.balance}
+          endTimestamp={showReleaseVaultModal.endTimestamp}
+          onClose={() => setShowReleaseVaultModal(undefined)}
         />
       )}
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,10 +58,10 @@
     prompts "^2.4.2"
     zod "^3.25.76"
 
-"@ar.io/sdk@4.0.2-alpha.9":
-  version "4.0.2-alpha.9"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.0.2-alpha.9.tgz#c0f652a0aa803869e4f0063a72e2c7baba620e50"
-  integrity sha512-SSnQarIUFA2ICpQvuTUQQTalVOud1Etu5k+Ffu8r+TndJTX8Q307i799H+oaLJzVWDPMx6MaJ9wCoUzl6Nl1AQ==
+"@ar.io/sdk@4.1.0-alpha.2":
+  version "4.1.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-4.1.0-alpha.2.tgz#ffba125940fd7e5f4f8be252a447fae1f84b0dcb"
+  integrity sha512-dTLhjX8HNGSIcUmx7VfszqmpsAeL+uZgmekMqnPmT/FlUUBIsTSEA1DBzowdpJJe9Yx67ZbH13jz7OTJI6or4Q==
   dependencies:
     "@ar.io/solana-contracts" "1.0.1"
     "@noble/hashes" "^1.8.0"


### PR DESCRIPTION
## What

Investor/team token vaults reached their unlock date but tokens did not appear in wallets. On Solana a vault does not auto-credit at expiry — the owner must call `release_vault`, which transfers the balance to their wallet and closes the vault (BD-050). This adds a clear, owner-driven way to do that.

- **`ReleaseVaultModal.tsx`** (new) — mirrors `RevokeVaultModal` look/feel (`BaseModal` / `LabelValueRow` / `Button` / `BlockingMessageModal` / `SuccessModal`). No "type CONFIRM" gate since release is non-destructive (you receive your own tokens).
- **`VaultsTable.tsx`** — per-vault **Release** action, shown when the connected wallet **owns** an **unlocked (expired)** vault. Revoke is unchanged in intent but now correctly scoped to controller + pre-expiry; both render in one actions column.

The Dashboard "Claim All Rewards" bulk-release path already existed and starts working again once the SDK fix lands (see below).

## Dependency — bump @ar.io/sdk before merge

This relies on the `@ar.io/sdk` fix where `getVaults()` returns the **numeric** `vaultId` (release/revoke derive the PDA via `BigInt(vaultId)`; the old pubkey-as-id threw, which silently broke both Release and Revoke): ar-io/ar-io-sdk#692.

This branch still pins the pre-fix `@ar.io/sdk@4.0.2-alpha.9`. **Before merge:** bump `@ar.io/sdk` to the version published from that PR and `yarn install`. Verified locally against the fixed SDK via `yarn link`.

## Verification

- `tsc --build` against the fixed SDK — clean
- `yarn build` (tsc + vite) — clean
- `biome check` — clean
- Manual (pending): connect an owner wallet with an unlocked mainnet vault, click Release, sign, confirm tokens land and the vault closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6EYzND97UZFweq4gNxjQ4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new vault release flow for eligible unlocked vaults.
  * Vaults now show a **Release** action for the connected wallet when a vault is available to reclaim.
  * Added a confirmation and success experience, including transaction tracking and a link to view it in the Solana explorer.

* **Bug Fixes**
  * Improved vault action visibility so users only see actions they can actually perform.

* **Chores**
  * Updated the SDK dependency to a newer alpha version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->