### PR TITLE
fix(observers): read observation counts from the Epoch account

### DIFF
--- a/src/hooks/useObserversWithCount.ts
+++ b/src/hooks/useObserversWithCount.ts
@@ -33,12 +33,24 @@ const useObserversWithCount = (epochCount: number) => {
         .filter((epoch) => epoch !== undefined)
         .sort((a, b) => a!.epochIndex - b!.epochIndex);
 
+      // An epoch fetched through the SDK fallback carries no counter. Charting
+      // it as 0 would be indistinguishable from "nobody observed" — the exact
+      // failure this hook was changed to stop — so omit it rather than guess.
+      const withCounters = available.filter(
+        (epoch) => typeof epoch!.observationsSubmitted === 'number',
+      );
+      if (withCounters.length !== available.length) {
+        log.warn(
+          `[useObserversWithCount] omitting ${available.length - withCounters.length} epoch(s) with no observationsSubmitted counter rather than rendering them as 0`,
+        );
+      }
+
       // Read the durable counter off the Epoch account rather than counting
       // Observation PDAs — those are closed for rent once an epoch
       // distributes, so counting them yields 0 for every past epoch.
-      const results = available.map((epoch) => {
+      const results = withCounters.map((epoch) => {
         const prescribedObservers = epoch!.prescribedObservers.length;
-        const reportsCount = epoch!.observationsSubmitted ?? 0;
+        const reportsCount = epoch!.observationsSubmitted as number;
         const performancePercentage =
           prescribedObservers > 0
             ? (reportsCount / prescribedObservers) * 100

--- a/src/hooks/useObserversWithCount.ts
+++ b/src/hooks/useObserversWithCount.ts
@@ -3,59 +3,12 @@ import { useGlobalState } from '@src/store';
 import { useQuery } from '@tanstack/react-query';
 import useEpochsWithCount from './useEpochsWithCount';
 
-const OBSERVATION_DISCRIMINATOR = new Uint8Array([
-  0x6d, 0xbe, 0xbe, 0x5f, 0x1c, 0xac, 0xf3, 0x4a,
-]);
-
 export type ObserverHistoricalStats = {
   epochIndex: number;
   reportsCount: number;
   performancePercentage: number;
   prescribedObservers: number;
 };
-
-/**
- * Count observation PDAs for a given epoch. Uses dataSlice to fetch
- * only account keys (no data), minimizing response size.
- */
-export async function countObservationsForEpoch(
-  rpc: any,
-  garProgram: string,
-  epochIndex: number,
-): Promise<number> {
-  const discBytes = btoa(String.fromCharCode(...OBSERVATION_DISCRIMINATOR));
-  const epochBuf = new Uint8Array(8);
-  new DataView(epochBuf.buffer).setBigUint64(0, BigInt(epochIndex), true);
-  const epochBytes = btoa(String.fromCharCode(...epochBuf));
-
-  try {
-    const accounts = await rpc
-      .getProgramAccounts(garProgram as any, {
-        encoding: 'base64',
-        dataSlice: { offset: 0, length: 0 },
-        filters: [
-          {
-            memcmp: {
-              offset: 0n,
-              bytes: discBytes,
-              encoding: 'base64',
-            },
-          },
-          {
-            memcmp: {
-              offset: 8n,
-              bytes: epochBytes,
-              encoding: 'base64',
-            },
-          },
-        ],
-      })
-      .send();
-    return accounts.length;
-  } catch {
-    return 0;
-  }
-}
 
 const useObserversWithCount = (epochCount: number) => {
   const rpc = useGlobalState((state) => state.rpc);
@@ -80,27 +33,24 @@ const useObserversWithCount = (epochCount: number) => {
         .filter((epoch) => epoch !== undefined)
         .sort((a, b) => a!.epochIndex - b!.epochIndex);
 
-      const results = await Promise.all(
-        available.map(async (epoch) => {
-          const prescribedObservers = epoch!.prescribedObservers.length;
-          const reportsCount = await countObservationsForEpoch(
-            rpc,
-            garProgram,
-            epoch!.epochIndex,
-          );
-          const performancePercentage =
-            prescribedObservers > 0
-              ? (reportsCount / prescribedObservers) * 100
-              : 0;
+      // Read the durable counter off the Epoch account rather than counting
+      // Observation PDAs — those are closed for rent once an epoch
+      // distributes, so counting them yields 0 for every past epoch.
+      const results = available.map((epoch) => {
+        const prescribedObservers = epoch!.prescribedObservers.length;
+        const reportsCount = epoch!.observationsSubmitted ?? 0;
+        const performancePercentage =
+          prescribedObservers > 0
+            ? (reportsCount / prescribedObservers) * 100
+            : 0;
 
-          return {
-            epochIndex: epoch!.epochIndex,
-            reportsCount,
-            performancePercentage,
-            prescribedObservers,
-          };
-        }),
-      );
+        return {
+          epochIndex: epoch!.epochIndex,
+          reportsCount,
+          performancePercentage,
+          prescribedObservers,
+        };
+      });
 
       log.info(
         `[useObserversWithCount] ${results.length} epochs, reports: ${results.map((r) => `${r.epochIndex}:${r.reportsCount}`).join(', ')}`,

--- a/src/pages/Dashboard/ObserverPerformancePanel.tsx
+++ b/src/pages/Dashboard/ObserverPerformancePanel.tsx
@@ -1,10 +1,8 @@
 import Placeholder from '@src/components/Placeholder';
 import Streak from '@src/components/Streak';
 import useEpochSettings from '@src/hooks/useEpochSettings';
-import useObservations from '@src/hooks/useObservations';
 import useObserversWithCount from '@src/hooks/useObserversWithCount';
-import { useGlobalState } from '@src/store';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Area,
   AreaChart,
@@ -42,50 +40,13 @@ const CustomTooltip = ({
 const EPOCH_COUNT = 7; // Contract retains ~7 epochs on-chain
 
 const ObserverPerformancePanel = () => {
-  const currentEpoch = useGlobalState((state) => state.currentEpoch);
   const { data: epochSettings } = useEpochSettings();
   const { data: historicalObserverStats } = useObserversWithCount(EPOCH_COUNT);
 
-  // Live observation data for the current epoch
-  const { data: observations } = useObservations(currentEpoch);
-  const reportsCount = observations
-    ? Object.keys(observations.reports).length
-    : undefined;
-  const prescribedCount = currentEpoch
-    ? currentEpoch.prescribedObservers.length
-    : undefined;
-
-  // Patch the current epoch entry with live observation data from
-  // useObservations. The epoch object's embedded observations are empty
-  // (lightweight fetch doesn't populate them), so without this the
-  // current epoch always shows 0/50.
-  const chartData = useMemo(() => {
-    if (!historicalObserverStats) return undefined;
-    if (reportsCount === undefined || prescribedCount === undefined) {
-      return historicalObserverStats;
-    }
-
-    const patched = [...historicalObserverStats];
-    const lastIndex = patched.length - 1;
-    if (
-      lastIndex >= 0 &&
-      patched[lastIndex].epochIndex === currentEpoch?.epochIndex
-    ) {
-      patched[lastIndex] = {
-        ...patched[lastIndex],
-        reportsCount,
-        prescribedObservers: prescribedCount,
-        performancePercentage:
-          prescribedCount > 0 ? (reportsCount / prescribedCount) * 100 : 0,
-      };
-    }
-    return patched;
-  }, [
-    historicalObserverStats,
-    reportsCount,
-    prescribedCount,
-    currentEpoch?.epochIndex,
-  ]);
+  // `observationsSubmitted` comes off the Epoch account and is accurate for
+  // the live epoch too, so the current entry no longer needs patching from
+  // the (rent-reclaimed) Observation PDAs.
+  const chartData = historicalObserverStats;
 
   const [activeIndex, setActiveIndex] = useState<number>();
   const [percentageChange, setPercentageChange] = useState<number>();

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -1,7 +1,9 @@
-import { EpochData } from '@ar.io/sdk/web';
 import { log } from '@src/constants';
 import { Assessment } from '@src/types';
-import { fetchEpochLightweight } from '@src/utils/epochFetch';
+import {
+  type EpochDataWithCounters,
+  fetchEpochLightweight,
+} from '@src/utils/epochFetch';
 import { getErrorMessage } from '@src/utils/getErrorMessage';
 import Dexie, { type EntityTable } from 'dexie';
 
@@ -11,7 +13,7 @@ export type NetworkPortalDB = Dexie & {
     'id' // primary key "id" (for the typings only)
   >;
   epochs: EntityTable<
-    EpochData,
+    EpochDataWithCounters,
     'epochIndex' // primary key "id" (for the typings only)
   >;
 };
@@ -48,6 +50,15 @@ export const createDb = (dbName: string = 'solana-mainnet') => {
     epochs: 'epochIndex',
   });
 
+  // v3: epochs cached by v2 predate `observationsSubmitted`, so they would
+  // report 0 observations forever. Drop them once; they refetch on demand.
+  db.version(3)
+    .stores({
+      observations: '++id, timestamp, gatewayAddress',
+      epochs: 'epochIndex',
+    })
+    .upgrade((tx) => tx.table('epochs').clear());
+
   db.open().catch(function (err) {
     console.error('Failed to open db: ', err);
   });
@@ -69,7 +80,7 @@ export const getEpoch = async (
     return epoch;
   }
 
-  let epochData: EpochData | undefined;
+  let epochData: EpochDataWithCounters | undefined;
   try {
     epochData = await fetchEpochLightweight(rpc, garProgram, epochIndex);
   } catch (error) {
@@ -93,7 +104,10 @@ export const getEpoch = async (
     );
   }
 
-  if (epochData) {
+  // Only cache epochs whose counters are final. An epoch that hasn't
+  // distributed yet can still take observations, and caching it here would
+  // freeze `observationsSubmitted` at whatever it was on first view.
+  if (epochData && epochData.rewardsDistributed) {
     try {
       await networkPortalDB.epochs.add(epochData);
     } catch (e) {

--- a/src/store/globalState.ts
+++ b/src/store/globalState.ts
@@ -2,7 +2,6 @@ import type { SolanaARIOWriteable, SolanaRpc } from '@ar.io/sdk/solana';
 import {
   ARIO,
   ARIORead,
-  EpochData,
   createCircuitBreakerRpc,
   defaultFallbackUrl,
 } from '@ar.io/sdk/web';
@@ -10,6 +9,7 @@ import { address, createSolanaRpc } from '@solana/kit';
 import type { Rpc, SolanaRpcApi } from '@solana/kit';
 import { THEME_TYPES } from '@src/constants';
 import { AoAddress } from '@src/types';
+import type { EpochDataWithCounters } from '@src/utils/epochFetch';
 import { getOptionalSolanaAddress } from '@src/utils/solanaAddress';
 import { create } from 'zustand';
 import { shallow } from 'zustand/shallow';
@@ -25,7 +25,7 @@ type GlobalState = {
   arIOReadSDK: ARIORead;
   arIOWriteableSDK?: SolanaARIOWriteable;
   solanaSlot?: number;
-  currentEpoch?: EpochData;
+  currentEpoch?: EpochDataWithCounters;
   walletAddress?: AoAddress;
   walletStateInitialized: boolean;
   ticker: string;
@@ -36,7 +36,7 @@ type GlobalState = {
 type GlobalStateActions = {
   setTheme: (theme: ThemeType) => void;
   setSolanaSlot: (slot: number) => void;
-  setCurrentEpoch: (currentEpoch?: EpochData) => void;
+  setCurrentEpoch: (currentEpoch?: EpochDataWithCounters) => void;
   updateWallet: (walletAddress?: AoAddress) => void;
   setWalletStateInitialized: (initialized: boolean) => void;
   setTicker: (ticker: string) => void;
@@ -164,7 +164,7 @@ class GlobalStateActionBase implements GlobalStateActions {
     this.set({ solanaSlot });
   };
 
-  setCurrentEpoch = (currentEpoch?: EpochData) => {
+  setCurrentEpoch = (currentEpoch?: EpochDataWithCounters) => {
     this.set({ currentEpoch });
   };
 

--- a/src/utils/epochFetch.ts
+++ b/src/utils/epochFetch.ts
@@ -8,6 +8,24 @@ const DEFAULT_ADDRESS = '11111111111111111111111111111111';
 const secToMs = (n: number): number => n * 1000;
 
 /**
+ * `EpochData` plus the two counters that live on the Epoch account itself.
+ *
+ * These matter because `Observation` PDAs are deleted by the permissionless
+ * `close_observation` once an epoch distributes (it refunds the observer's
+ * rent). Counting those PDAs therefore returns 0 for every completed epoch.
+ * `Epoch.observations_submitted` is incremented on submit and is never
+ * cleared, so it is the only durable source for historical participation.
+ *
+ * Optional because the SDK fallback path (`getCurrentEpoch()`) returns a
+ * plain `EpochData` without them; consumers should treat absent as unknown.
+ */
+export type EpochDataWithCounters = EpochData & {
+  observationsSubmitted?: number;
+  /** 1 once `distribute_epoch` has run — the epoch's counters are final. */
+  rewardsDistributed?: number;
+};
+
+/**
  * Fetch an epoch by index using a single RPC call (getAccount on the
  * Epoch PDA), then build the EpochData shape from the raw on-chain data.
  * This is ~25x faster than the SDK's getEpoch() which makes ~55 calls
@@ -22,7 +40,7 @@ export async function fetchEpochLightweight(
   garProgram: string,
   epochIndex: number,
   commitment: Commitment = 'confirmed',
-): Promise<EpochData> {
+): Promise<EpochDataWithCounters> {
   const [epochPda] = await getEpochPDA(epochIndex, garProgram as any);
   const epochAccount = await fetchEncodedAccount(rpc, epochPda, {
     commitment,
@@ -56,6 +74,8 @@ export async function fetchEpochLightweight(
 
   return {
     epochIndex,
+    observationsSubmitted: epochData.observationsSubmitted,
+    rewardsDistributed: epochData.rewardsDistributed,
     startHeight: 0,
     startTimestamp: secToMs(epochData.startTimestamp),
     endTimestamp: secToMs(epochData.endTimestamp),


### PR DESCRIPTION
## Problem

The Observer Performance chart showed **0 for every past epoch**.

Both `useObserversWithCount` and the SDK's `getObservations()` count `Observation` PDAs. But `close_observation` deletes those once an epoch distributes — it refunds the observer's rent, so it's expected to run. The query is therefore structurally empty for any completed epoch.

On mainnet right now, only **2** observation accounts exist, while the epochs themselves record 8–12 submissions each:

| epoch | submitted | closed |
|---|---|---|
| 501 | 10 | 10 |
| 502 | 9 | 9 |
| 503 | 9 | 9 |
| 504 | 12 | 12 |
| 505 | 8 | 8 |
| 506 (live) | 4 | 0 |

`observations_closed == observations_submitted` for every settled epoch — the data was never missing, the accounts were just reclaimed.

## Fix

`Epoch.observations_submitted` is incremented on submit and never cleared, so it survives PDA closure. `fetchEpochLightweight` already decodes it via `deserializeEpoch` — it just wasn't propagated, because the SDK's `EpochData` type has no field for it.

- **`epochFetch`** — add `EpochDataWithCounters`, carry `observationsSubmitted` + `rewardsDistributed` out of the decode
- **`useObserversWithCount`** — drop `countObservationsForEpoch` and its hardcoded discriminator; read the counter. **Removes one `getProgramAccounts` per epoch**
- **`ObserverPerformancePanel`** — drop the current-epoch patching workaround and its `useObservations` query; the counter is accurate live too
- **`db`** — Dexie v3 clears cached epochs (v2 entries predate the field and would report 0 forever), and only cache epochs that have distributed so an epoch cached mid-flight can't freeze its count
- **`globalState`** — widen `currentEpoch` to the counter-bearing type

Net −55 lines.

## Verification

Decoded through the installed `@ar.io/sdk@4.1.0-alpha.2` against mainnet. Epochs 501–505 produce **10/9/9/12/8 of 50**, matching raw chain reads and an independent popcount of the `has_observed` bitmap.

The denominator decodes as **50**, which confirms the client isn't built for shrunk registry sizes — `prescribed_observers` sits after `failure_counts[3000]`, so a mis-sized client would have silently corrupted it.

`tsc` clean · `biome` clean · `vitest` 33/33 · `yarn build` passes.

## Deploy note

First load after deploy clears each user's cached epochs (the Dexie v3 upgrade). One-time refetch, and it's why the version bump is load-bearing rather than cosmetic.

## Out of scope

Per-observer detail — who reported, report tx ids, per-gateway failure attribution — is still empty for closed epochs. It affects the Observers table, Observers banner, Gateway snitch rows, and the Report page. Most of it is recoverable from the durable `has_observed` bitmap and `failure_counts` on the same Epoch account; report links need the Arweave reports. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKeNoHyV6m1Z3sh81Jykkf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Observer performance statistics now load faster using persisted epoch-level counts.
  * Historical performance charts use consistent epoch statistics without live-data adjustments.
  * Epoch data now includes observation and reward counters for more reliable tracking.
  * Cached epoch information is refreshed safely when the data format changes.
  * Undistributed epoch data is available immediately without being saved to cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->