### PR TITLE
release: v2.4.1 — fix 401 for returning users after endpoint rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-08-18
+
+### Fixed
+
+- Returning users hitting `401 Unauthorized` on every RPC call after 2.4.0. Settings
+  persist to localStorage, and the merge let a stored value win over the build's
+  defaults — its only reset trigger compared localhost against remote, so an RPC
+  endpoint saved by an older build survived every upgrade. When the provider token
+  was rotated for 2.4.0, everyone who had opened the app before kept calling the
+  revoked endpoint while new visitors were fine.
+
+  The settings store is now versioned. Upgrading from the unversioned store drops
+  the stored endpoint and the program ids keyed to it, so the shipped defaults apply
+  again. Preferences unrelated to the network are preserved.
+
+  Without this, every future endpoint rotation would silently break existing users
+  the same way.
+
 ## [2.4.0] - 2026-08-17
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ar-io/network-portal",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --build tsconfig.build.json && cross-env NODE_OPTIONS=--max-old-space-size=32768 vite build",

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -169,10 +169,48 @@ const isLocalRpcUrl = (rpcUrl: string | undefined): boolean => {
   }
 };
 
+export const SETTINGS_VERSION = 1;
+
+/**
+ * v0 (unversioned) -> v1: drop persisted network configuration.
+ *
+ * `merge` lets persisted values win over the build's defaults, and its only
+ * reset trigger compares localhost-vs-remote — so an endpoint saved by an older
+ * build survives forever. When a provider auth token is rotated, every returning
+ * user keeps calling the revoked one and gets 401 on every request, while new
+ * visitors are fine. Dropping the stored endpoint (and the program ids keyed to
+ * it) lets the shipped defaults apply again.
+ *
+ * Non-network preferences (sidebar, GQL endpoint) are deliberately preserved.
+ */
+export const migrateSettings = (
+  persistedState: unknown,
+  fromVersion: number,
+): Partial<Settings> => {
+  const persistedSettings = (persistedState ?? {}) as Partial<Settings>;
+
+  if (fromVersion >= SETTINGS_VERSION) {
+    return persistedSettings;
+  }
+
+  const migrated = { ...persistedSettings };
+  delete migrated.solanaRpcUrl;
+  delete migrated.solanaAddressSettingsByNetwork;
+  for (const key of SOLANA_ADDRESS_SETTING_KEYS) {
+    delete migrated[key];
+  }
+
+  return migrated;
+};
+
 export const useSettings = create<Settings>()(
   subscribeWithSelector(
     persist(() => DEFAULT_SETTINGS, {
       name: 'settings',
+      // Bumping SETTINGS_VERSION resets stored network config once — see
+      // migrateSettings for why that is necessary after an endpoint rotation.
+      version: SETTINGS_VERSION,
+      migrate: migrateSettings,
       merge: (persistedState, currentState) => {
         const persistedSettings = (persistedState ?? {}) as Partial<Settings>;
         const mergedState = {

--- a/tests/store/settings.test.ts
+++ b/tests/store/settings.test.ts
@@ -1,0 +1,86 @@
+import { SETTINGS_VERSION, migrateSettings } from '@src/store/settings';
+
+/**
+ * Regression cover for the 401 that followed a provider token rotation.
+ *
+ * `merge` lets persisted values win over the build's defaults, so an RPC
+ * endpoint saved by an older build outlives the upgrade that replaced it. Once
+ * the old auth token is revoked, every returning user calls a dead endpoint
+ * while new visitors are fine — which is exactly what shipped in v2.4.0.
+ */
+describe('migrateSettings', () => {
+  const legacyState = {
+    solanaRpcUrl:
+      'https://example-old.solana-mainnet.quiknode.pro/revokedtoken/',
+    solanaCoreProgramId: 'CoreOld',
+    solanaGarProgramId: 'GarOld',
+    solanaArnsProgramId: 'ArnsOld',
+    solanaAntProgramId: 'AntOld',
+    bridgeBalanceAddress: 'BridgeOld',
+    solanaAddressSettingsByNetwork: {
+      'https://example-old.solana-mainnet.quiknode.pro/revokedtoken/': {
+        solanaCoreProgramId: 'CoreOld',
+      },
+    },
+    sidebarOpen: false,
+    arweaveGqlUrl: 'https://gql.example/graphql',
+  };
+
+  it('drops an endpoint persisted by an older build', () => {
+    const migrated = migrateSettings(legacyState, 0);
+
+    expect(migrated).not.toHaveProperty('solanaRpcUrl');
+  });
+
+  it('drops program ids keyed to the old endpoint', () => {
+    const migrated = migrateSettings(legacyState, 0) as Record<string, unknown>;
+
+    for (const key of [
+      'solanaCoreProgramId',
+      'solanaGarProgramId',
+      'solanaArnsProgramId',
+      'solanaAntProgramId',
+      'bridgeBalanceAddress',
+      'solanaAddressSettingsByNetwork',
+    ]) {
+      expect(migrated).not.toHaveProperty(key);
+    }
+  });
+
+  it('preserves preferences unrelated to the network', () => {
+    const migrated = migrateSettings(legacyState, 0);
+
+    expect(migrated.sidebarOpen).toBe(false);
+    expect(migrated.arweaveGqlUrl).toBe('https://gql.example/graphql');
+  });
+
+  it('does not mutate the state handed to it', () => {
+    migrateSettings(legacyState, 0);
+
+    expect(legacyState.solanaRpcUrl).toBe(
+      'https://example-old.solana-mainnet.quiknode.pro/revokedtoken/',
+    );
+  });
+
+  it('leaves an already-migrated store untouched', () => {
+    const current = {
+      solanaRpcUrl: 'https://example-new.solana-mainnet.quiknode.pro/live/',
+    };
+
+    expect(migrateSettings(current, SETTINGS_VERSION)).toEqual(current);
+  });
+
+  it('does not re-run on a future version', () => {
+    const current = {
+      solanaRpcUrl: 'https://example-new.solana-mainnet.quiknode.pro/live/',
+    };
+
+    expect(migrateSettings(current, SETTINGS_VERSION + 1)).toEqual(current);
+  });
+
+  it('tolerates an absent or empty persisted store', () => {
+    expect(migrateSettings(undefined, 0)).toEqual({});
+    expect(migrateSettings(null, 0)).toEqual({});
+    expect(migrateSettings({}, 0)).toEqual({});
+  });
+});


### PR DESCRIPTION
## v2.4.1

Hotfix for the `401 Unauthorized` that returning users hit after v2.4.0. Deploys to Firebase and **Arweave (permanent)**.

Secrets are already set and verified from the 2.4.0 release — no prerequisite this time.

### The bug

v2.4.0 shipped correctly: CI passed the secrets, the build inlined the new endpoints, and the deployed bundle authenticated fine. I verified all of that against the live permaweb app.

What none of it caught: settings persist to localStorage, and `merge` lets a persisted value win over the build's defaults. Its only reset trigger compares localhost against remote —

```js
const networkTierChanged =
  isLocalRpcUrl(previousSolanaRpcUrl) !== isLocalRpcUrl(SOLANA_RPC_URL);
```

— so old-remote → new-remote never trips it. An endpoint saved by an older build survives every upgrade.

`DEFAULT_SETTINGS.solanaRpcUrl` is the mainnet endpoint, and 2.4.0 rotated that token. So **everyone who had opened the app before kept calling the revoked endpoint**, while new visitors were fine. Confirmed against the live endpoints: old `44d938fa…` → 401, new `7cc00b48…` → 200.

That asymmetry is why every check passed — fresh requests, incognito, and CI all exercise the new-visitor path.

### The fix

`version: 1` on the persisted store plus a `migrate` that drops the stored endpoint and the program ids keyed to it, so the shipped defaults apply again. Preferences unrelated to the network are preserved.

The durable win: **without this, every future endpoint rotation breaks existing users the same way.**

### Verification

- 40/40 tests (7 new on the extracted `migrateSettings`)
- `tsc --noEmit` clean
- `biome check` clean across 212 files
- CI green on #329

Store-level hydration is deliberately untested — importing the store pulls the full `@ar.io/sdk` module graph and exceeds the test timeout. My first attempt at such a test passed with the fix reverted (async hydration meant it asserted pre-hydration defaults), so I removed it rather than keep a test that proved nothing.

### After deploy

Affected users are fixed on next load. No action needed from them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)